### PR TITLE
feat: prefer `_esm` traitlet over `_module` for JS source

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export function render(view) {
 # ESM = "http://localhost:5173/index.js"
 
 class CounterWidget(anywidget.AnyWidget):
-    _module = traitlets.Unicode(ESM).tag(sync=True) # required, must be ESM
+    _esm = traitlets.Unicode(ESM).tag(sync=True) # required, must be ESM
     count = traitlets.Int(0).tag(sync=True)
 ```
 

--- a/examples/Counter-hooks.ipynb
+++ b/examples/Counter-hooks.ipynb
@@ -63,7 +63,7 @@
     "\"\"\"\n",
     "\n",
     "class CounterWidget(anywidget.AnyWidget):\n",
-    "    _module = traitlets.Unicode(ESM).tag(sync=True)\n",
+    "    _esm = traitlets.Unicode(ESM).tag(sync=True)\n",
     "    count = traitlets.Int(0).tag(sync=True)"
    ]
   },
@@ -105,7 +105,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/examples/Counter-htm.ipynb
+++ b/examples/Counter-htm.ipynb
@@ -42,7 +42,7 @@
     "\"\"\"\n",
     "\n",
     "class CounterWidget(anywidget.AnyWidget):\n",
-    "    _module = traitlets.Unicode(ESM).tag(sync=True)\n",
+    "    _esm = traitlets.Unicode(ESM).tag(sync=True)\n",
     "    count = traitlets.Int(0).tag(sync=True)"
    ]
   },
@@ -84,7 +84,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/examples/Counter.ipynb
+++ b/examples/Counter.ipynb
@@ -52,7 +52,7 @@
     "\"\"\"\n",
     "\n",
     "class CounterWidget(anywidget.AnyWidget):\n",
-    "    _module = traitlets.Unicode(ESM).tag(sync=True)\n",
+    "    _esm = traitlets.Unicode(ESM).tag(sync=True)\n",
     "    count = traitlets.Int(0).tag(sync=True)"
    ]
   },
@@ -76,6 +76,14 @@
    "source": [
     "counter.count"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4715be2e-dc7b-4f2b-8fac-acff9a74c888",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -94,7 +102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/src/widget.js
+++ b/src/widget.js
@@ -93,7 +93,7 @@ export default function (base) {
 	class AnyView extends base.DOMWidgetView {
 		async render() {
 			await load_css(this.model.get("_css"), this.model.get("_anywidget_id"));
-			let widget = await load_esm(this.model.get("_module"));
+			let widget = await load_esm(this.model.get("_esm") ?? this.model.get("_module"));
 			await widget.render(this);
 		}
 	}


### PR DESCRIPTION
Renames `_module` traitlet to `_esm`. `_module` is still supported but will be deprecated.

```diff
class CounterWidget(anywidget.AnyWidget):
-    _module = traitlets.Unicode(ESM).tag(sync=True)
+    _esm = traitlets.Unicode(ESM).tag(sync=True)

    count = traitlets.Int(0).tag(sync=True)

```