### PR TITLE
feat: Add conda installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,16 @@ Learn more in [the announcement](https://anywidget.dev/blog/introducing-anywidge
 
 > **Warning**: **anywidget** is new and under active development. It is not yet ready for production as APIs are subject to change.
 
-```
+anywidget is available on [PyPI](https://pypi.org/project/anywidget/). To install anywidget, run the following command:
+
+```bash
 pip install anywidget
+```
+
+anywidget is also available on [conda-forge](https://anaconda.org/conda-forge/anywidget). If you have [Anaconda](https://www.anaconda.com/distribution/#download-section) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html) installed on your computer, you can install anywidget using the following command:
+
+```bash
+conda install -c conda-forge anywidget
 ```
 
 ## Usage
@@ -74,13 +82,13 @@ Note for developers:
 
 For developing with JupyterLab:
 
-```
+```bash
 jupyter labextension develop --overwrite anywidget
 ```
 
 ## Release
 
-```
+```bash
 npm version [major|minor|patch]
 git tag -a vX.X.X -m "vX.X.X"
 git push --follow-tags


### PR DESCRIPTION
I have added anywidget to conda-forge. This PR adds instructions for installing anywidget using conda.
https://anaconda.org/conda-forge/anywidget

@manzt Would you be willing to be listed as a maintainer of the conda-forge recipe? There is minimal maintenance work we need to do. Most of the time the repo can do auto merge using the bot. If the dependencies of the package change, then we need to submit a PR to update the recipe. 
https://github.com/conda-forge/anywidget-feedstock