### PR TITLE
feat: Support custom serializers

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -121,7 +121,6 @@ let anywidgetMarker = Symbol("anywidget");
  * @param {{ [K in OverrideKeys]: T[K] }} overrides
  */
 function readonly_proxy(obj, overrides) {
-	/** @type {ISerializers} */
 	return new Proxy(obj, {
 		get(target, prop, receiver) {
 			// tag our proxy
@@ -157,8 +156,7 @@ async function setup_model(view, { Model, widget }) {
 		 */
 
 		// TODO: allow users to override `DOMWidgetModel.serializers`?
-		// Seems like more trouble than it's worth, just pick a new name
-		// and keep things simple.
+		// Seems like more trouble than it's worth, just pick a new name and keep things simple.
 		for (let key in widget.serializers) {
 			if (key in Model.serializers) {
 				throw TypeError(


### PR DESCRIPTION
This is a WIP in progress at providing at declarative API for supporting custom serializers in **anywidget**. Custom `serializers` are a fairly advanced widget concept, but can be useful for handling custom data-types (specifically binary data). 

This PR implements support via another (optional) ESM export, `serializers`:

```javascript
export const serializers = {
  my_value: {
    deserialize: (value, manager) => /* ... */,
    serialize: (value, manager) => /* ... */,
  }
}

export function render(view) {
  let deserialized = view.model.get("my_value");
  /* ... */
}
```

which extends the `DOMWidgetModel.serializers` like when defining traditional Jupyter Widgets. 

## More trouble than it's worth?

The main challenge with supporting custom `serializers` is that the Jupyter Widgets framework relies on serializers being defined statically on a unique model that extends from `DOMWidgetModel`.  All **anywidget**'s derive from the _same_ `AnyModel` class, so we can't just modify `AnyModel` itself (because one widget could override the serializers for another). Further, we don't have access to the `_esm` until after the model has been initialized, so we can't know the serializers until after initialization.

The key to the proposed solution, is that following Widget Model initialization, the Jupyter Widgets framework accesses the statically defined serializers via the model _instance_ constructor (i.e., `model.constructor`) for all [comm messages](https://github.com/jupyter-widgets/ipywidgets/blob/74774dae5becb9f4781c3438a5fece1f8ca60415/packages/base/src/widget.ts#L265). Through the magic of JavaScript [Proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy), we can inspect and intercept access to `model.constructor`, effectively enabling the re-definition of properties on `AnyModel` for a specific `model` _instance_ in a controlled manner.

```javascript
let overrides = { serializers };
this.model.constructor = readonly_proxy(AnyModel, overrides);
// this.model now users the above serializers in `_deserialize_state`, rather than whatever was defined on `AnyModel` originally

// merged serializers 
this.model.constructor = readonly_proxy(AnyModel, { serializers: { ...AnyModel.serializers, ...serializers } });

// original behavior
this.model.constructor = AnyModel; // restore behavior
```

While this solution works currently, there are several issues that make me nervous:

- We can't register serializers until _after_ the initial state has been deserialized. This means that we need manually deserialize _some_ of the model state the first time we encounter a model instance.

- It's a hack. This implementation relies heavily on an implementation detail in Jupyter Widgets, which could change and then what are we to do.

- Manually performing serialization/deserialization isn't that bad and would be more stable.

## Alternatives?

Originally I thought that custom `serializers` was a very low-level mechanism of transforming data to/from Python (i.e., handling bytes), but upon further inspection  it's just an additional hook provided by Jupyter Widgets to _further_ transform an already JSON-decoded object. Essentially, serializers are just syntactic sugar for:

```javascript
const deserialize = (value, manager) => /* ... */;
const serialize = (value, manager) => /* ... */;

// export const serializers = { my_value: { deserialize, serialize } };

let deserialized = await deserialize(view.model.get("my_value"), view.model.widget_manager));

let serialized = serialize(value, view.model.widget_manager);
view.model.set("my_value",  serialized);
```

Which is fairly easy to write helpers for in user code. It begs the question of whether we should put in all this effort to have a similar declarative API or just suggest users write little serializer utilities for accessing state. Odds are they have a helper like:

```javascript
function getCount() {
	return view.model.get("count");
}
```

and is it too much to ask for it to be changed to

```javascript
function getCount() {
	let serialized = view.model.get("count");
	return deserializeCount(serialized, view.model.widget_manager);
}
```

If needed?

Finally, a limitation of Jupyter Widgets serializers is that `deserialize` can be asynchronous but `serialize` cannot. This means if you require async transformations for `serialization` you have to manually serialize/deserialize the state like the snippet above (i.e., you can't use the builtin serialization mechanim).

