### PR TITLE
chore: add .gitattributes for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+vite-plugin.js linguist-vendored
+anywidget/nbextension/extension.js linguist-vendored
+src/index.js linguist-vendored
+src/plugin.js linguist-vendored
+


### PR DESCRIPTION
The [linguist](https://github.com/github/linguist/blob/master/docs/overrides.md#documentation) breakdown for the repo might give the impression that **anywidget** is a JavaScript library. This PR tells linguist to treat some JS files as vendored (i.e., some boilerplate and the vite plugin), so that the language breakdown is a better reflection of the project.

Now,

```bash
❯ github-linguist -b
61.76%  5064       Python
38.24%  3136       JavaScript

Python:
anywidget/__init__.py
anywidget/_version.py
anywidget/widget.py
setup.py
tests/test_widget.py

JavaScript:
src/widget.js
```



