### PR TITLE
docs: enable DocSearch

### DIFF
--- a/docs/src/consts.ts
+++ b/docs/src/consts.ts
@@ -36,9 +36,9 @@ export const COMMUNITY_INVITE_URL = "";
 
 // See "Algolia" section of the README for more information.
 export const ALGOLIA = {
-	indexName: "XXXXXXXXXX",
-	appId: "XXXXXXXXXX",
-	apiKey: "XXXXXXXXXX",
+	indexName: "anywidget",
+	appId: "5UZQUZZNXI",
+	apiKey: "f8be8ea567a2b746ccc3986f9db3a129",
 };
 
 export type Sidebar = Record<

--- a/docs/src/env.d.ts
+++ b/docs/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />


### PR DESCRIPTION
**anywidget** was accepted for [DocSearch program](https://docsearch.algolia.com/docs/docsearch-program/)! This PR enables their search on the website. It's appears that it's fine to keep the Algolia API keys in the repo (Astro and Vite both do this).
