### PR TITLE
fix: dynamically set _ipython_display_ for widgets in Google Colab

### DIFF
--- a/anywidget/__init__.py
+++ b/anywidget/__init__.py
@@ -1,15 +1,5 @@
-import sys
-
 from ._version import __version__  # noqa
 from .widget import AnyWidget  # noqa
-
-try:
-    if "google.colab" in sys.modules:
-        from google.colab import output  # type: ignore
-
-        output.enable_custom_widget_manager()
-except ImportError:
-    pass
 
 
 def _jupyter_labextension_paths():

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -52,13 +52,18 @@ class AnyWidget(ipywidgets.DOMWidget):
 
         self.add_traits(**anywidget_traits)
 
+        # Check if we are in Colab
         if "google.colab.output" in sys.modules:
+
+            # Enable custom widgets manager so that our widgets display in Colab
+            # https://github.com/googlecolab/colabtools/issues/498#issuecomment-998308485
             if not type(self)._enabled_colab_widget_manager:
                 output = sys.modules.get("google.colab.output")
                 output.enable_custom_widget_manager()  # type: ignore
                 type(self)._enabled_colab_widget_manager = True
 
-            # monkey-patch _ipython_display_ for Google Colab
+            # Monkey-patch _ipython_display_ for each instance if missing.
+            # Necessary for Colab to display third-party widget
             # see https://github.com/manzt/anywidget/issues/48
             if not hasattr(self, "_ipython_display_"):
 

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -52,14 +52,10 @@ class AnyWidget(ipywidgets.DOMWidget):
 
         self.add_traits(**anywidget_traits)
 
-        if "google.colab" in sys.modules:
+        if "google.colab.output" in sys.modules:
             if not type(self)._enabled_colab_widget_manager:
-                import contextlib
-
-                with contextlib.suppress(ImportError):
-                    from google.colab import output  # type: ignore
-
-                    output.enable_custom_widget_manager()
+                output = sys.modules.get("google.colab.output")
+                output.enable_custom_widget_manager()  # type: ignore
                 type(self)._enabled_colab_widget_manager = True
 
             # monkey-patch _ipython_display_ for Google Colab

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -1,3 +1,5 @@
+import sys
+
 import ipywidgets
 import traitlets.traitlets as t
 
@@ -48,3 +50,18 @@ class AnyWidget(ipywidgets.DOMWidget):
         ).tag(sync=True)
 
         self.add_traits(**anywidget_traits)
+
+        # monkey-patch _ipython_display_ for Google Colab
+        # see https://github.com/manzt/anywidget/issues/48
+        if "google.colab" in sys.modules and not hasattr(self, "_ipython_display_"):
+            from google.colab import output
+
+            output.enable_custom_widget_manager()
+
+            def _ipython_display_(**kwargs):
+                from IPython.display import display
+
+                data = self._repr_mimebundle_(**kwargs)
+                display(data, raw=True)
+
+            self._ipython_display_ = _ipython_display_

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -54,7 +54,6 @@ class AnyWidget(ipywidgets.DOMWidget):
 
         # Check if we are in Colab
         if "google.colab.output" in sys.modules:
-
             # Enable custom widgets manager so that our widgets display in Colab
             # https://github.com/googlecolab/colabtools/issues/498#issuecomment-998308485
             if not type(self)._enabled_colab_widget_manager:

--- a/tests/test_colab.py
+++ b/tests/test_colab.py
@@ -1,28 +1,40 @@
+import pytest
 import collections
-import unittest.mock as mock
+from unittest.mock import patch, MagicMock
 import sys
 
 import anywidget
+
+import IPython.display
 
 
 def fake_module(**kwargs: dict):
     return collections.namedtuple("module", *kwargs.keys())(**kwargs)
 
 
-def test_enables_widget_manager_in_colab():
-    fn = mock.Mock()
-    fake = fake_module(enable_custom_widget_manager=fn)
-    with mock.patch.dict(sys.modules, {"google.colab.output": fake}):
-        anywidget.AnyWidget()
-        anywidget.AnyWidget()
-        assert fn.assert_called_once
+@pytest.fixture
+def mock_colab():
+    enable_custom_widget_manager = MagicMock()
+    mock_module = fake_module(enable_custom_widget_manager=enable_custom_widget_manager)
+    with patch.dict(sys.modules, {"google.colab.output": mock_module}):
+        yield mock_module
 
 
-def test_adds_ipython_display_in_colab():
-    fake = fake_module(enable_custom_widget_manager=lambda: None)
-    with mock.patch.dict(sys.modules, {"google.colab.output": fake}):
-        w = anywidget.AnyWidget()
-        assert hasattr(w, "_ipython_display_")
+def test_enables_widget_manager_in_colab(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_colab: MagicMock,
+):
+    mock_display = MagicMock()
+    monkeypatch.setattr(IPython.display, "display", mock_display)
+
+    anywidget.AnyWidget()
+    anywidget.AnyWidget()
+    w = anywidget.AnyWidget()
+    assert mock_colab.enable_custom_widget_manager.assert_called_once
+
+    assert hasattr(w, "_ipython_display_")
+    w._ipython_display_()
+    assert mock_display.assert_called_once
 
 
 def test_default_no_ipython_display():

--- a/tests/test_colab.py
+++ b/tests/test_colab.py
@@ -1,0 +1,62 @@
+import collections
+import unittest.mock as mock
+import sys
+
+import anywidget
+
+
+def fake_module(**args):
+    return collections.namedtuple("module", args.keys())(**args)
+
+
+def get_patch_dict(dotted_module_path, module):
+    patch_dict = {}
+    module_splits = dotted_module_path.split(".")
+
+    # Add our module to the patch dict
+    patch_dict[dotted_module_path] = module
+
+    # We add the rest of the fake modules in backwards
+    while module_splits:
+        # This adds the next level up into the patch dict which is a fake
+        # module that points at the next level down
+        patch_dict[".".join(module_splits[:-1])] = fake_module(
+            **{module_splits[-1]: patch_dict[".".join(module_splits)]}
+        )
+        module_splits = module_splits[:-1]
+
+    return patch_dict
+
+
+def test_enables_widget_manager_in_colab():
+    enable_custom_widget_manager = mock.Mock()
+
+    with mock.patch.dict(
+        sys.modules,
+        get_patch_dict(
+            "google.colab.output",
+            fake_module(enable_custom_widget_manager=enable_custom_widget_manager),
+        ),
+    ):
+        anywidget.AnyWidget()
+
+        assert enable_custom_widget_manager.called
+
+
+def test_adds_ipython_display_in_colab():
+    enable_custom_widget_manager = mock.Mock()
+
+    with mock.patch.dict(
+        sys.modules,
+        get_patch_dict(
+            "google.colab.output",
+            fake_module(enable_custom_widget_manager=enable_custom_widget_manager),
+        ),
+    ):
+        w = anywidget.AnyWidget()
+        assert hasattr(w, "_ipython_display_")
+
+
+def test_default_no_ipython_display():
+    w = anywidget.AnyWidget()
+    assert not hasattr(w, "_ipython_display_")

--- a/tests/test_colab.py
+++ b/tests/test_colab.py
@@ -1,39 +1,25 @@
-import pytest
-import collections
-from unittest.mock import patch, MagicMock
 import sys
+from unittest.mock import MagicMock
+
+import IPython.display
+import pytest
 
 import anywidget
 
-import IPython.display
 
+def test_enables_widget_manager_in_colab(monkeypatch: pytest.MonkeyPatch):
+    mock = MagicMock()
+    monkeypatch.setitem(sys.modules, "google.colab.output", mock)
 
-def fake_module(**kwargs: dict):
-    return collections.namedtuple("module", *kwargs.keys())(**kwargs)
-
-
-@pytest.fixture
-def mock_colab():
-    enable_custom_widget_manager = MagicMock()
-    mock_module = fake_module(enable_custom_widget_manager=enable_custom_widget_manager)
-    with patch.dict(sys.modules, {"google.colab.output": mock_module}):
-        yield mock_module
-
-
-def test_enables_widget_manager_in_colab(
-    mock_colab: MagicMock,
-):
     anywidget.AnyWidget()
     anywidget.AnyWidget()
-    assert mock_colab.enable_custom_widget_manager.assert_called_once
+    assert mock.enable_custom_widget_manager.assert_called_once
 
 
-def test_ipython_display_in_colab(
-    monkeypatch: pytest.MonkeyPatch,
-    mock_colab: MagicMock,
-):
+def test_ipython_display_in_colab(monkeypatch: pytest.MonkeyPatch):
     mock_display = MagicMock()
     monkeypatch.setattr(IPython.display, "display", mock_display)
+    monkeypatch.setitem(sys.modules, "google.colab.output", MagicMock())
 
     w = anywidget.AnyWidget()
 

--- a/tests/test_colab.py
+++ b/tests/test_colab.py
@@ -5,55 +5,22 @@ import sys
 import anywidget
 
 
-def fake_module(**args):
-    return collections.namedtuple("module", args.keys())(**args)
-
-
-def get_patch_dict(dotted_module_path, module):
-    patch_dict = {}
-    module_splits = dotted_module_path.split(".")
-
-    # Add our module to the patch dict
-    patch_dict[dotted_module_path] = module
-
-    # We add the rest of the fake modules in backwards
-    while module_splits:
-        # This adds the next level up into the patch dict which is a fake
-        # module that points at the next level down
-        patch_dict[".".join(module_splits[:-1])] = fake_module(
-            **{module_splits[-1]: patch_dict[".".join(module_splits)]}
-        )
-        module_splits = module_splits[:-1]
-
-    return patch_dict
+def fake_module(**kwargs: dict):
+    return collections.namedtuple("module", *kwargs.keys())(**kwargs)
 
 
 def test_enables_widget_manager_in_colab():
-    enable_custom_widget_manager = mock.Mock()
-
-    with mock.patch.dict(
-        sys.modules,
-        get_patch_dict(
-            "google.colab.output",
-            fake_module(enable_custom_widget_manager=enable_custom_widget_manager),
-        ),
-    ):
+    fn = mock.Mock()
+    fake = fake_module(enable_custom_widget_manager=fn)
+    with mock.patch.dict(sys.modules, {"google.colab.output": fake}):
         anywidget.AnyWidget()
         anywidget.AnyWidget()
-
-        enable_custom_widget_manager.assert_called_once
+        assert fn.assert_called_once
 
 
 def test_adds_ipython_display_in_colab():
-    enable_custom_widget_manager = mock.Mock()
-
-    with mock.patch.dict(
-        sys.modules,
-        get_patch_dict(
-            "google.colab.output",
-            fake_module(enable_custom_widget_manager=enable_custom_widget_manager),
-        ),
-    ):
+    fake = fake_module(enable_custom_widget_manager=lambda: None)
+    with mock.patch.dict(sys.modules, {"google.colab.output": fake}):
         w = anywidget.AnyWidget()
         assert hasattr(w, "_ipython_display_")
 

--- a/tests/test_colab.py
+++ b/tests/test_colab.py
@@ -21,16 +21,21 @@ def mock_colab():
 
 
 def test_enables_widget_manager_in_colab(
+    mock_colab: MagicMock,
+):
+    anywidget.AnyWidget()
+    anywidget.AnyWidget()
+    assert mock_colab.enable_custom_widget_manager.assert_called_once
+
+
+def test_ipython_display_in_colab(
     monkeypatch: pytest.MonkeyPatch,
     mock_colab: MagicMock,
 ):
     mock_display = MagicMock()
     monkeypatch.setattr(IPython.display, "display", mock_display)
 
-    anywidget.AnyWidget()
-    anywidget.AnyWidget()
     w = anywidget.AnyWidget()
-    assert mock_colab.enable_custom_widget_manager.assert_called_once
 
     assert hasattr(w, "_ipython_display_")
     w._ipython_display_()

--- a/tests/test_colab.py
+++ b/tests/test_colab.py
@@ -39,8 +39,9 @@ def test_enables_widget_manager_in_colab():
         ),
     ):
         anywidget.AnyWidget()
+        anywidget.AnyWidget()
 
-        assert enable_custom_widget_manager.called
+        enable_custom_widget_manager.assert_called_once
 
 
 def test_adds_ipython_display_in_colab():


### PR DESCRIPTION
Fixes #48

Dynamically adds `_ipython_display_` method to an instance of `anywidget.widget.AnyWidget` if both:

1. detect we are in a Google Colab and 
2. `_ipython_display_` is not already implemented

Importantly, this PR changes the previous behavior of calling `google.colab.outputs.enable_custom_widget_manager()` to within the `anywidget.AnyWidget` constructor. From my experimenting, there seems to be no issue with executing this function each time we create a new instance. ~I think ideally we call this enable function only the _first_ time we detect a widget instance in a colab. Maybe some state that lives on the class?~

EDIT: The enable_custom_widgets_manager is now only excuted once. Originally I had a `functools.cache` init function, but didn't realize that wasn't available in older python 3 versions. There might be a more elegant way to do it than the path I've chosen.
