### PR TITLE
chore: remove gitattributes for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,0 @@
-vite-plugin.js linguist-vendored
-anywidget/nbextension/extension.js linguist-vendored
-src/index.js linguist-vendored
-src/plugin.js linguist-vendored
-


### PR DESCRIPTION
Reverts #36

**anywidget** is undoubtably a Python project now and we don't need to try to game GitHub's metadata.
