### PR TITLE
feat: native HMR

### DIFF
--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -305,7 +305,7 @@ class ReprMimeBundle:
         if obj is None:
             return  # pragma: no cover  ... the python object has been deleted
 
-        state = {**self._get_state(obj), **self._extra_state}
+        state = {**self._extra_state, **self._get_state(obj)}
         if include is not None:
             include = {include} if isinstance(include, str) else set(include)
             state = {k: v for k, v in state.items() if k in include}

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -368,7 +368,6 @@ class ReprMimeBundle:
             },
         }
 
-
     def sync_object_with_view(
         self, py_to_js: bool = True, js_to_py: bool = True
     ) -> None:
@@ -423,11 +422,14 @@ class ReprMimeBundle:
             with contextlib.suppress(Exception):
                 self._disconnectors.pop()()
 
-    def send_hmr_update(self, **data: dict):
-        self._comm.send({
-            "method": "custom",
-            "content": { "type": "anywidget:hmr", "data": data },
-        })
+    def send_hmr_update(self, esm: str | None = None, css: str | None = None):
+        data = {"esm": esm, "css": css}
+        self._comm.send(
+            {
+                "method": "custom",
+                "content": {"type": "anywidget:hmr", "data": data},
+            }
+        )
 
 
 # ------------- Helper function --------------

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -305,7 +305,7 @@ class ReprMimeBundle:
         if obj is None:
             return  # pragma: no cover  ... the python object has been deleted
 
-        state = {**self._extra_state, **self._get_state(obj)}
+        state = {**self._get_state(obj), **self._extra_state}
         if include is not None:
             include = {include} if isinstance(include, str) else set(include)
             state = {k: v for k, v in state.items() if k in include}
@@ -368,6 +368,7 @@ class ReprMimeBundle:
             },
         }
 
+
     def sync_object_with_view(
         self, py_to_js: bool = True, js_to_py: bool = True
     ) -> None:
@@ -421,6 +422,12 @@ class ReprMimeBundle:
         while self._disconnectors:
             with contextlib.suppress(Exception):
                 self._disconnectors.pop()()
+
+    def send_hmr_update(self, **data: dict):
+        self._comm.send({
+            "method": "custom",
+            "content": { "type": "anywidget:hmr", "data": data },
+        })
 
 
 # ------------- Helper function --------------

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -432,12 +432,16 @@ class ReprMimeBundle:
         css : string, optional
             anywidget front-end CSS code. Can be raw text or URL.
         """
-        self._comm.send(
-            {
-                "method": "custom",
-                "content": {"type": "anywidget:hmr", "data": {"esm": esm, "css": css}},
-            }
-        )
+        update = {}
+
+        if esm is not None:
+            update["_esm"] = esm
+
+        if css is not None:
+            update["_css"] = css
+
+        self._extra_state.update(update)
+        self.send_state(set(update.keys()))
 
 
 # ------------- Helper function --------------

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -422,7 +422,7 @@ class ReprMimeBundle:
             with contextlib.suppress(Exception):
                 self._disconnectors.pop()()
 
-    def send_hmr_update(self, esm: str | None = None, css: str | None = None):
+    def _send_hmr_update(self, esm: str | None = None, css: str | None = None):
         """Send new ESM or CSS for front end to load and re-render the current views.
 
         Parameters
@@ -441,7 +441,7 @@ class ReprMimeBundle:
             update["_css"] = css
 
         self._extra_state.update(update)
-        self.send_state(set(update.keys()))
+        self.send_state(update.keys())
 
 
 # ------------- Helper function --------------

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -423,11 +423,19 @@ class ReprMimeBundle:
                 self._disconnectors.pop()()
 
     def send_hmr_update(self, esm: str | None = None, css: str | None = None):
-        data = {"esm": esm, "css": css}
+        """Send new ESM or CSS for front end to load and re-render the current views.
+
+        Parameters
+        ----------
+        esm : string, optional
+            anywidget front-end JavaScript code. Can be raw text or URL.
+        css : string, optional
+            anywidget front-end CSS code. Can be raw text or URL.
+        """
         self._comm.send(
             {
                 "method": "custom",
-                "content": {"type": "anywidget:hmr", "data": data},
+                "content": {"type": "anywidget:hmr", "data": {"esm": esm, "css": css}},
             }
         )
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -92,6 +92,21 @@ async function load_esm(esm) {
 	return widget;
 }
 
+/**
+ * @typedef AnyWidgetHMRUpdate
+ * @prop {"anywidget:hmr"} type
+ * @prop {{ esm?: string, css?: string }} data
+ */
+
+/**
+ * @param {unknown} msg
+ * @return {msg is AnyWidgetHMRUpdate}
+ */
+function is_anywidget_update(msg) {
+	if (typeof msg !== "object" || msg == null) return false;
+	return "type" in msg && msg.type === "anywidget:hmr";
+}
+
 /** @param {typeof import("@jupyter-widgets/base")} base */
 export default function (base) {
 	class AnyModel extends base.DOMWidgetModel {
@@ -107,34 +122,37 @@ export default function (base) {
 		initialize(...args) {
 			super.initialize(...args);
 
-			this.on("change:_css", () => {
-				load_css(this.get("_css"), this.get("_anywidget_id"));
-			});
+			this.on("msg:custom", async (msg) => {
+				if (!is_anywidget_update(msg)) return;
 
-			this.on("change:_esm", async () => {
-				let widget = await load_esm(this.get("_esm"));
+				let { esm, css } = msg.data;
 
-				Object.values(this.views ?? {}).forEach(async (promise) => {
-					let view = await promise;
+				if (typeof esm === "string") {
+					let widget = await load_esm(esm);
+					for await (let view of Object.values(this.views ?? {})) {
+						// Unsubscribe from any handlers registered to `view.listenTo`
+						// Sadly we can't just `model.off` because it removes everything,
+						// including handlers not setup by the child view.
+						//
+						// We could override `model.on` with a particular `context` if none is
+						// provided, letting us unsubscribe from only events from views
+						// e.g., `model.off(null, null, anywidgetSymbol)`, but that might
+						// be more trouble than it's worth and this is just a feature for
+						// development.
+						view.stopListening(this);
 
-					// Unsubscribe from any handlers registered to `view.listenTo`
-					// Sadly we can't just `model.off` because it removes everything,
-					// including handlers not setup by the child view.
-					//
-					// We could override `model.on` with a particular `context` if none is
-					// provided, letting us unsubscribe from only events from views
-					// e.g., `model.off(null, null, anywidgetSymbol)`, but that might
-					// be more trouble than it's worth and this is just a feature for
-					// development.
-					view.stopListening(this);
+						// Clean up all child elements except for the root
+						while (view.el.firstChild) {
+							view.el.removeChild(view.el.firstChild);
+						}
 
-					// Clean up all child elements except for the root
-					while (view.el.firstChild) {
-						view.el.removeChild(view.el.firstChild);
+						widget.render(view);
 					}
+				}
 
-					widget.render(view);
-				});
+				if (typeof css === "string") {
+					load_css(css, this.get("_anywidget_id"));
+				}
 			});
 		}
 	}

--- a/src/widget.js
+++ b/src/widget.js
@@ -3,7 +3,7 @@ import { name, version } from "../package.json";
 
 /**
  *  @typedef AnyWidgetModule
- *  @prop render {(view: import("@jupyter-widgets/base").DOMWidgetView) => Promise<void>}
+ *  @prop render {(view: import("@jupyter-widgets/base").WidgetView) => Promise<void>}
  */
 
 /**
@@ -102,6 +102,41 @@ export default function (base) {
 		static view_name = "AnyView";
 		static view_module = name;
 		static view_module_version = version;
+
+		/** @param {Parameters<InstanceType<base["DOMWidgetModel"]>["initialize"]>} args */
+		initialize(...args) {
+			super.initialize(...args);
+
+			this.on("change:_css", () => {
+				load_css(this.get("_css"), this.get("_anywidget_id"));
+			});
+
+			this.on("change:_esm", async () => {
+				let widget = await load_esm(this.get("_esm"));
+
+				Object.values(this.views ?? {}).forEach(async (promise) => {
+					let view = await promise;
+
+					// Unsubscribe from any handlers registered to `view.listenTo`
+					// Sadly we can't just `model.off` because it removes everything,
+					// including handlers not setup by the child view.
+					//
+					// We could override `model.on` with a particular `context` if none is
+					// provided, letting us unsubscribe from only events from views
+					// e.g., `model.off(null, null, anywidgetSymbol)`, but that might
+					// be more trouble than it's worth and this is just a feature for
+					// development.
+					view.stopListening(this);
+
+					// Clean up all child elements except for the root
+					while (view.el.firstChild) {
+						view.el.removeChild(view.el.firstChild);
+					}
+
+					widget.render(view);
+				});
+			});
+		}
 	}
 
 	class AnyView extends base.DOMWidgetView {

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -77,6 +77,29 @@ def test_descriptor(mock_comm: MagicMock) -> None:
     mock_comm.send.assert_called()
 
 
+def test_descriptor_sends_hmr_update(mock_comm: MagicMock) -> None:
+    """Test that descriptor sends custom anywidget HMR update to front end."""
+
+    esm = "export function render(view) {}"
+    css = "h1 { }"
+
+    class Foo:
+        _repr_mimebundle_ = MimeBundleDescriptor(autodetect_observer=False)
+        value: int = 0
+
+        def _get_anywidget_state(self):
+            return {"value": self.value}
+
+    foo = Foo()
+    foo._repr_mimebundle_.send_hmr_update(esm=esm, css=css)
+    mock_comm.send.assert_called_with(
+        {
+            "method": "custom",
+            "content": {"type": "anywidget:hmr", "data": {"esm": esm, "css": css}},
+        }
+    )
+
+
 def test_state_setter(mock_comm: MagicMock):
     """Test that `_set_anywidget_state` is used when present."""
     mock = MagicMock()

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -93,10 +93,12 @@ def test_descriptor_sends_hmr_update(mock_comm: MagicMock) -> None:
     foo = Foo()
     foo._repr_mimebundle_.send_hmr_update(esm=esm, css=css)
     mock_comm.send.assert_called_with(
-        {
-            "method": "custom",
-            "content": {"type": "anywidget:hmr", "data": {"esm": esm, "css": css}},
-        }
+        data={
+            "method": "update",
+            "state": {"_esm": esm, "_css": css},
+            "buffer_paths": [],
+        },
+        buffers=[],
     )
 
 

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -118,7 +118,6 @@ def test_descriptor_sends_hmr_update(mock_comm: MagicMock) -> None:
     mock_comm.send.assert_not_called
 
 
-
 def test_state_setter(mock_comm: MagicMock):
     """Test that `_set_anywidget_state` is used when present."""
     mock = MagicMock()

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -91,7 +91,8 @@ def test_descriptor_sends_hmr_update(mock_comm: MagicMock) -> None:
             return {"value": self.value}
 
     foo = Foo()
-    foo._repr_mimebundle_.send_hmr_update(esm=esm, css=css)
+
+    foo._repr_mimebundle_._send_hmr_update(esm=esm, css=css)
     mock_comm.send.assert_called_with(
         data={
             "method": "update",
@@ -100,6 +101,22 @@ def test_descriptor_sends_hmr_update(mock_comm: MagicMock) -> None:
         },
         buffers=[],
     )
+
+    foo._repr_mimebundle_._send_hmr_update(esm=esm)
+    mock_comm.send.assert_called_with(
+        data={"method": "update", "state": {"_esm": esm}, "buffer_paths": []},
+        buffers=[],
+    )
+
+    foo._repr_mimebundle_._send_hmr_update(css=css)
+    mock_comm.send.assert_called_with(
+        data={"method": "update", "state": {"_css": css}, "buffer_paths": []},
+        buffers=[],
+    )
+
+    foo._repr_mimebundle_._send_hmr_update()
+    mock_comm.send.assert_not_called
+
 
 
 def test_state_setter(mock_comm: MagicMock):


### PR DESCRIPTION
Right now "best-in-class" widget development is only enabled when developers setup Vite and use its HMR. However, it's kind of annoying to setup Vite with **anywidget** and get the [two playing together](https://anywidget.dev/en/bundling/). 

This PR is an experiment to enable granular HMR  updates _within_ **anywidget** and be agnostic to bundlers or dev-servers. The trick is that we can send messages to an `AnyModel` any time the front-end code is updated, and then clear existing views and re-render the model. This means we could build adapters on the python side for various JS setups.

https://user-images.githubusercontent.com/24403730/217332349-eec5e4c2-1004-4cef-aff5-995a6f936bae.mov

```python
from anywidget._descriptor import MimeBundleDescriptor
from psygnal import evented
from dataclasses import dataclass

@evented
@dataclass
class Counter:
    _repr_mimebundle_ = MimeBundleDescriptor()
    _esm: str = "export function render(view) { view.el.innerText = 'oops, nothing to see here' }"
    _css: str = ""
    value: int = 0

counter = Counter()
counter
```

```python
counter._esm = """
export function render(view) {
  let count = () => view.model.get("value");
  let btn = document.createElement("button");
  btn.innerHTML = `count is ${count()}`;
  btn.classList.add("counter-button")
  btn.addEventListener("click", () => {
    view.model.set("value", count() + 1);
    view.model.save_changes();
  });
  view.model.on("change:value", () => { btn.innerHTML = `count is ${count()}` });
  view.el.appendChild(btn);
}
""" # updates the live counter
```

I think this mechanism can be leveraged to setup file-watchers for build assets, and automatically push changes to the frontend during development. My main thought at the moment is whether or not we should use events or send custom messages to the front end. I'm leaning towards the latter but this is a prototype.