### PR TITLE
feat: add `FileContents` to read/watch files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[test]
+          pip install -e .[dev,test]
 
       - name: Run tests
         run: pytest ./tests --color=yes --cov anywidget --cov-report xml
-      
+
       - uses: codecov/codecov-action@v3
 
   Build:

--- a/anywidget/_file_contents.py
+++ b/anywidget/_file_contents.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+from collections import deque
+
+import pathlib
+import threading
+from typing import Iterator
+
+from psygnal import Signal
+
+
+class FileContents:
+    """Object that watches for file changes and emits a signal when it changes.
+
+    Calling `str(obj)` on this object will always return the current contents of the
+    file (as long as the thread is running).
+
+    Parameters
+    ----------
+    path : str | pathlib.Path
+        The file to read and watch for content changes
+    start_thread : bool, optional
+        Whether to start watching for changes in a separate thread (default: `True`)
+    """
+
+    changed = Signal(str)
+    deleted = Signal()
+
+    def __init__(self, path: str | pathlib.Path, start_thread: bool = True):
+        self._path = pathlib.Path(path).expanduser().absolute()
+        if not self._path.is_file():
+            raise ValueError("File does not exist: {self._path}")
+        self._contents: str | None = None  # cached contents, cleared on change
+        self._stop_event = threading.Event()
+        self._background_thread: threading.Thread | None = None
+        if start_thread:
+            self.watch_in_thread()
+
+    def watch_in_thread(self) -> None:
+        """Watch for file changes (and emitting signals) from a separate thread."""
+        if self._background_thread is not None:
+            return
+        self._stop_event.clear()
+        self._background_thread = threading.Thread(
+            target=lambda: deque(self.watch(), maxlen=0),
+            daemon=True,
+        )
+        self._background_thread.start()
+
+    def stop_thread(self) -> None:
+        """Stops an actively running thread if it exists."""
+        if self._background_thread is None:
+            return
+        self._stop_event.set()
+        self._background_thread.join()
+        self._background_thread = None
+
+    def watch(self) -> Iterator[tuple[int, str]]:
+        """Watch for file changes and emit changed/deleted signal events.
+
+        Blocks indefinitely.
+
+        Returns
+        -------
+        changes : Iterator[tuple[int, str]]
+            An iterator that yields any time the file changes until the file is deleted.
+        """
+        from watchfiles import Change, watch
+
+        for changes in watch(self._path, stop_event=self._stop_event):
+            for change, path in changes:
+                if change == Change.deleted:
+                    self.deleted.emit()
+                    return
+                # Only getting Change.added events on macOS so we listen for either
+                if change == Change.modified or change == Change.added:
+                    self._contents = None
+                    self.changed.emit(str(self))
+                    yield (change, path)
+                    break
+
+    def __str__(self) -> str:
+        if self._contents is None:
+            self._contents = self._path.read_text()
+        return self._contents

--- a/anywidget/_file_contents.py
+++ b/anywidget/_file_contents.py
@@ -41,6 +41,9 @@ class FileContents:
             return
         self._stop_event.clear()
         self._background_thread = threading.Thread(
+            # self.watch() returns a generator, so the thread would exit
+            # immediately if we passed `target=self.watch`. The `deque`
+            # forces the thread to run until it exhausts our generator.
             target=lambda: deque(self.watch(), maxlen=0),
             daemon=True,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ test = [
     "pytest",
     "pytest-cov",
     "ruff==0.0.238",
+    "watchfiles",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,13 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "black[jupyter]",
-    "psygnal",
     "pydantic",
     "pytest",
     "pytest-cov",
     "ruff==0.0.238",
+]
+dev = [
+    "psygnal",
     "watchfiles",
 ]
 
@@ -71,7 +73,7 @@ path = "package.json"
 pattern = "\"version\": \"(?P<version>.+?)\""
 
 [tool.hatch.envs.default]
-features = ["test"]
+features = ["test", "dev"]
 
 [tool.hatch.envs.default.scripts]
 fmt = "black ."

--- a/tests/test_file_contents.py
+++ b/tests/test_file_contents.py
@@ -29,25 +29,15 @@ def test_file_contents_deleted(tmp_path: pathlib.Path):
     path = tmp_path / "foo.txt"
     path.write_text(CONTENTS)
 
-    contents = FileContents(path, start_thread=False)
+    contents = FileContents(path)
+
     mock = Mock()
     contents.deleted.connect(mock)
-
-    def mock_file_events():
-        changes = set()
-        changes.add((Change.deleted, str(path)))
-        yield changes
-        changes = set()
-        changes.add((Change.modified, str(path)))
-        yield changes
-
-    with patch.object(watchfiles, "watch") as mock_watch:
-        mock_watch.return_value = mock_file_events()
-        total = sum(1 for _ in contents.watch())
-
-    assert total == 0
-    mock_watch.assert_called_with(path, stop_event=contents._stop_event)
-    assert mock.called
+    path.unlink()
+    assert contents._background_thread
+    contents._background_thread.join()
+    assert not contents._background_thread.is_alive()
+    mock.assert_called()
 
 
 def test_file_contents_changed(tmp_path: pathlib.Path):

--- a/tests/test_file_contents.py
+++ b/tests/test_file_contents.py
@@ -10,22 +10,17 @@ from watchfiles import Change
 from anywidget._file_contents import FileContents
 
 
-def test_file_contents_no_watch(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
-):
+def test_file_contents_no_watch(tmp_path: pathlib.Path):
     """Test __str__ reads file contents and does not start a thread"""
-    mock = MagicMock()
-    monkeypatch.setattr(watchfiles, "watch", mock)
-
     CONTENTS = "hello, world"
     path = tmp_path / "foo.txt"
     path.write_text(CONTENTS)
 
-    contents = FileContents(path, start_thread=False)
-
-    assert str(contents) == CONTENTS
-    assert contents._background_thread is None
-    mock.assert_not_called
+    with patch.object(watchfiles, "watch") as mock:
+        contents = FileContents(path, start_thread=False)
+        assert str(contents) == CONTENTS
+        assert contents._background_thread is None
+    mock.assert_not_called()
 
 
 def test_file_contents_deleted(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path):

--- a/tests/test_file_contents.py
+++ b/tests/test_file_contents.py
@@ -49,6 +49,7 @@ def test_file_contents_deleted(tmp_path: pathlib.Path):
     mock_watch.assert_called_with(path, stop_event=contents._stop_event)
     assert mock.called
 
+
 def test_file_contents_changed(tmp_path: pathlib.Path):
     """Test file changes emit changed signals and update the string contents"""
     CONTENTS = "hello, world"

--- a/tests/test_file_contents.py
+++ b/tests/test_file_contents.py
@@ -1,0 +1,162 @@
+import pathlib
+import time
+from collections import deque
+from unittest.mock import MagicMock, Mock
+
+import pytest
+import watchfiles
+from watchfiles import Change
+
+from anywidget._file_contents import FileContents
+
+
+def test_file_contents_no_watch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+):
+    """Test __str__ reads file contents and does not start a thread"""
+    mock = MagicMock()
+    monkeypatch.setattr(watchfiles, "watch", mock)
+
+    CONTENTS = "hello, world"
+    path = tmp_path / "foo.txt"
+    path.write_text(CONTENTS)
+
+    contents = FileContents(path, start_thread=False)
+
+    assert str(contents) == CONTENTS
+    assert contents._background_thread is None
+    mock.assert_not_called
+
+
+def test_file_contents_deleted(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path):
+    """Test deleting a file emits a deleted signal and stops the watcher"""
+    CONTENTS = "hello, world"
+    path = tmp_path / "foo.txt"
+    path.write_text(CONTENTS)
+
+    def mock_file_events():
+        changes = set()
+        changes.add((Change.deleted, str(path)))
+        yield changes
+        changes = set()
+        changes.add((Change.modified, str(path)))
+        yield changes
+
+    mock_watch = MagicMock(return_value=mock_file_events())
+    monkeypatch.setattr(watchfiles, "watch", mock_watch)
+
+    contents = FileContents(path, start_thread=False)
+    mock = Mock()
+    contents.deleted.connect(mock)
+
+    total = sum(1 for _ in contents.watch())
+    assert total == 0
+    mock_watch.assert_called_with(path, stop_event=contents._stop_event)
+    assert mock.called
+
+
+def test_file_contents_changed(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path):
+    """Test file changes emit changed signals and update the string contents"""
+    CONTENTS = "hello, world"
+    path = tmp_path / "foo.txt"
+    path.write_text(CONTENTS)
+    contents = FileContents(path, start_thread=False)
+
+    NEW_CONTENTS = "blah"
+
+    def mock_file_events():
+        path.write_text(NEW_CONTENTS)
+        changes = set()
+        changes.add((Change.modified, str(path)))
+        yield changes
+
+    mock_watch = MagicMock(return_value=mock_file_events())
+    monkeypatch.setattr(watchfiles, "watch", mock_watch)
+
+    mock = MagicMock()
+    contents.changed.connect(mock)
+
+    deque(contents.watch(), maxlen=0)
+
+    mock.assert_called_with(NEW_CONTENTS)
+    assert str(contents) == NEW_CONTENTS
+
+
+def test_file_contents_thread(tmp_path: pathlib.Path):
+    """Test runs watcher in background thread by default"""
+    path = tmp_path / "foo.txt"
+    path.touch()
+
+    contents = FileContents(path)
+
+    # thread on by default
+    assert contents._background_thread
+    assert not contents._stop_event.is_set()
+    assert contents._background_thread.is_alive()
+
+    # reuse the same thread
+    thread = contents._background_thread
+    contents.watch_in_thread()
+    assert contents._background_thread == thread
+
+    # stops the thread
+    contents.stop_thread()
+    assert contents._stop_event.is_set()
+    assert contents._background_thread is None
+
+    # no-op
+    contents.stop_thread()
+
+
+def test_background_file_contents(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+):
+    """Test background thread watcher sends signals and updates contents"""
+    CONTENTS = "hello, world"
+    path = tmp_path / "foo.txt"
+    path.write_text(CONTENTS)
+
+    contents = FileContents(path, start_thread=False)
+    mock_changed = MagicMock()
+    contents.changed.connect(mock_changed)
+
+    mock_deleted = MagicMock()
+    contents.deleted.connect(mock_deleted)
+
+    NEW_CONTENTS = "blah"
+
+    def mock_file_events():
+        # write to file
+        path.write_text(NEW_CONTENTS)
+        changes = set()
+        changes.add((Change.modified, str(path)))
+        yield changes
+        # delete the file
+        changes = set()
+        changes.add((Change.deleted, str(path)))
+        yield changes
+        # "re-create the file"
+        path.write_text(NEW_CONTENTS)
+        changes = set()
+        changes.add((Change.modified, str(path)))
+
+    mock_watch = MagicMock(return_value=mock_file_events())
+    monkeypatch.setattr(watchfiles, "watch", mock_watch)
+
+    contents.watch_in_thread()
+
+    while contents._background_thread and contents._background_thread.is_alive():
+        time.sleep(0.01)
+
+    mock_changed.assert_called_once_with(NEW_CONTENTS)
+    assert str(contents) == NEW_CONTENTS
+
+
+def test_missing_file_fails():
+    """Test missing file fails to construct"""
+    with pytest.raises(ValueError):
+        FileContents("not_a_file.txt")
+
+    with pytest.raises(ValueError):
+        FileContents(pathlib.Path("not_a_file.txt"))

--- a/tests/test_file_contents.py
+++ b/tests/test_file_contents.py
@@ -31,6 +31,9 @@ def test_file_contents_deleted(tmp_path: pathlib.Path):
 
     contents = FileContents(path)
 
+    while contents._background_thread and not contents._background_thread.is_alive():
+        time.sleep(0.1)
+
     mock = Mock()
     contents.deleted.connect(mock)
     path.unlink()


### PR DESCRIPTION
Closes #61

This PR adds the `anywidget._file_contents.FileContents` object. `FileContents` watches for file changes in a provided path in a background thread and continuously emits `changed` signals any time the file changes, until the file is deleted (emits a `deleted` event). Connecting `FileContents` with `MimeReprBuilder` or `AnyWidget` allows for #60 to be leveraged during development. Currently this must be done manually, but we should aim to make the creation of `FileContents` hidden.


#### With `traitlets`

```python
import anywidget
import traitlets
from anywidget._file_contents import FileContents

contents = FileContents("index.js")

class Counter(anywidget.AnyWidget):
    _esm = str(contents)
    value = traitlets.Int(0).tag(sync=True)

counter = Counter()
contents.changed.connect(lambda change: counter._esm = change)
counter
```

#### With `MimeReprBuilder`

```python
import anywidget
from anywidget._file_contents import FileContents
from anywidget._descriptor_ import MimeReprBuilder

contents = FileContents("index.js")

@evented
@dataclasses
class Counter:
    _repr_mimebundle_ = MimeReprBuilder(_esm=str(contents)
    value = traitlets.Int(0).tag(sync=True)

counter = Counter()
contents.changed.connect(lambda change: counter._send_hmr_update(esm=change))
counter
```
