### PR TITLE
chore: deprecate _module in favor of _esm

### DIFF
--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -6,6 +6,9 @@ import traitlets.traitlets as t
 
 from ._version import __version__
 
+_ANYWIDGET_ID_KEY = "_anywidget_id"
+_ESM_KEY = "_esm"
+_CSS_KEY = "_css"
 DEFAULT_ESM = """
 export function render(view) {
   console.log("Dev note: No _esm defined for this widget:", view);
@@ -42,18 +45,18 @@ class AnyWidget(ipywidgets.DOMWidget):
         # Add anywidget JS/CSS source as traits if not registered
         anywidget_traits = {
             k: t.Unicode(getattr(self, k)).tag(sync=True)
-            for k in ("_esm", "_module", "_css")
+            for k in (_ESM_KEY, _CSS_KEY)
             if hasattr(self, k) and not self.has_trait(k)
         }
 
         # show default _esm if not defined
-        if all(not hasattr(self, i) for i in ("_esm", "_module")):
-            anywidget_traits["_esm"] = t.Unicode(DEFAULT_ESM).tag(sync=True)
+        if not hasattr(self, _ESM_KEY):
+            anywidget_traits[_ESM_KEY] = t.Unicode(DEFAULT_ESM).tag(sync=True)
 
         # TODO: a better way to uniquely identify this subclasses?
         # We use the fully-qualified name to get an id which we
         # can use to update CSS if necessary.
-        anywidget_traits["_anywidget_id"] = t.Unicode(
+        anywidget_traits[_ANYWIDGET_ID_KEY] = t.Unicode(
             f"{self.__class__.__module__}.{self.__class__.__name__}"
         ).tag(sync=True)
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -155,9 +155,7 @@ export default function (base) {
 	class AnyView extends base.DOMWidgetView {
 		async render() {
 			await load_css(this.model.get("_css"), this.model.get("_anywidget_id"));
-			let widget = await load_esm(
-				this.model.get("_esm") ?? this.model.get("_module"),
-			);
+			let widget = await load_esm(this.model.get("_esm"));
 			await widget.render(this);
 		}
 	}

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -34,22 +34,6 @@ def test_basic():
     assert w._esm == ESM
 
 
-def test_legacy():
-    ESM = """
-    export function render(view) {
-        view.el.innerText = "Hello, world";
-    }
-    """
-
-    class Widget(anywidget.AnyWidget):
-        _module = t.Unicode(ESM).tag(sync=True)
-
-    w = Widget()
-
-    assert w.has_trait("_module")
-    assert w._module == ESM
-
-
 def test_default_esm():
     class Widget(anywidget.AnyWidget):
         ...


### PR DESCRIPTION
Requires users to specify `_esm` instead of the legacy `_module`, for their widget JavaScript code. We previously supported both, but I don't think this is necessary at v0.1 our docs only use `_esm` so the legacy syntax is very hidden.
