### PR TITLE
feat: add (optional) unmount return to render

### DIFF
--- a/.changeset/giant-pets-eat.md
+++ b/.changeset/giant-pets-eat.md
@@ -1,0 +1,14 @@
+---
+"anywidget": patch
+---
+
+feat: add (optional) cleanup/unmount return to `render`
+
+```javascript
+export function render(view) {
+  /* create elements and add event listeners */
+  return function cleanup() => {
+    /* specify how to cleanup any expensive resources created above */
+  }
+}
+```


### PR DESCRIPTION
anwidget doesn't currently expose an API for defining custom cleanup logic for a view. Typically, one would define this logic with `DOMWidgetView.remove()` so anywidget users _could_ mutate the `view` instance within `render` to achieve this behavior:

```javascript
export function render(view) {
  /* create dom elements and setup subscribers */
  let originalRemove = view.remove;
  view.remove = () => {
    /* cleanup event listeners/resources */
    originalRemove();
  }
}
```

but 1.) this requires some boilerplate to do correctly and 2.) we can't call `remove()` for hot reloading because it removes `view.el` from the DOM. 

So, some way we need users to be able to define custom cleanup for whatever they've setup in `render`. I think this lends itself nicely to a `React.useEffect`-like API, where `render` can optionally return a function to cleanup expensive resources created in `render`. 

```javascript
export function render(view) {
  /* create DOM elements and setup subscribers */
  return () => {
    /* optionally cleanup */
  }
}
```

I know that this introduces a new front-end API (which is something that I've been trying to avoid), but I think it is a rather necessary feature. A motivating example would be for something like `react` that will raise an exception if elements are unmounted without react:


```javascript
import * as React from "https://esm.sh/react@18";
import * as ReactDOM from "https://esm.sh/react-dom@18/client";

function App(props) {
  return <h1>Hello, world</h1>
}

export function render(view) {
  let root = ReactDOM.createRoot(view.el);
  root.render(<App />)
  return () => root.unmount();
}
```

<details>

<summary>compiled JSX</summary>

```javascript
import * as React from "https://esm.sh/react@18";
import * as ReactDOM from "https://esm.sh/react-dom@18/client";

function App(props) {
  return React.createElement("h1", null, "Hello, world");
}

export function render(view) {
  let root = ReactDOM.createRoot(view.el);
  root.render(React.createElement(App))
  return () => root.unmount();
}
```
</details>