### PR TITLE
feat: inject colab meta in `_repr_mimebundle_`

### DIFF
--- a/.changeset/yellow-bees-refuse.md
+++ b/.changeset/yellow-bees-refuse.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+feat: add colab metadata to `_repr_mimebundle_` to fix displaying ipywidgets v7 & v8 in Colab

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -25,7 +25,7 @@ import weakref
 from dataclasses import asdict, is_dataclass
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, cast, overload
 
-from ._util import put_buffers, remove_buffers
+from ._util import get_repr_metadata, put_buffers, remove_buffers
 from ._version import __version__
 from .widget import DEFAULT_ESM
 
@@ -355,11 +355,11 @@ class ReprMimeBundle:
     #     # https://github.com/jupyter-widgets/ipywidgets/blob/6547f840edc1884c75e60386ec7fb873ba13f21c/python/ipywidgets/ipywidgets/widgets/widget.py#L662
     #     ...
 
-    def __call__(self, **kwargs: Sequence[str]) -> dict:
+    def __call__(self, **kwargs: Sequence[str]) -> tuple[dict, dict]:
         """Called when _repr_mimebundle_ is called on the python object."""
         # NOTE: this could conceivably be a method on a Comm subclass
         # (i.e. the comm knows how to represent itself as a mimebundle)
-        return {
+        data = {
             "text/plain": repr(self),
             _JUPYTER_MIME: {
                 "version_major": _PROTOCOL_VERSION_MAJOR,
@@ -367,6 +367,7 @@ class ReprMimeBundle:
                 "model_id": self._comm.comm_id,
             },
         }
+        return data, get_repr_metadata()
 
     def sync_object_with_view(
         self, py_to_js: bool = True, js_to_py: bool = True

--- a/anywidget/_util.py
+++ b/anywidget/_util.py
@@ -130,7 +130,7 @@ def get_repr_metadata() -> dict:
         return {}
 
     _enable_custom_widget_manager_once()
-    url = sys.modules["google.colab.output"]._installed_url
+    url = sys.modules["google.colab.output"]._widgets._installed_url
 
     if url is None:
         return {}

--- a/anywidget/_util.py
+++ b/anywidget/_util.py
@@ -110,10 +110,17 @@ def put_buffers(
         obj[buffer_path[-1]] = buffer
 
 
+def in_colab() -> bool:
+    """Determines whether in Google Colab."""
+    return "google.colab.output" in sys.modules
+
+
 @lru_cache(maxsize=None)
-def _enable_custom_widget_manager_once() -> None:
-    # Enable custom widgets manager so that our widgets display in Colab
-    # https://github.com/googlecolab/colabtools/issues/498#issuecomment-998308485
+def enable_custom_widget_manager_once() -> None:
+    """Enables Google Colab's custom widget manager so third-party widgets display.
+
+    See https://github.com/googlecolab/colabtools/issues/498#issuecomment-998308485
+    """
     sys.modules["google.colab.output"].enable_custom_widget_manager()
 
 
@@ -126,10 +133,10 @@ def get_repr_metadata() -> dict:
 
     See https://github.com/manzt/anywidget/issues/63#issuecomment-1427194000.
     """
-    if "google.colab.output" not in sys.modules:
+    if not in_colab():
         return {}
 
-    _enable_custom_widget_manager_once()
+    enable_custom_widget_manager_once()
     url = sys.modules["google.colab.output"]._widgets._installed_url
 
     if url is None:

--- a/anywidget/_util.py
+++ b/anywidget/_util.py
@@ -111,7 +111,7 @@ def put_buffers(
 
 
 @lru_cache(maxsize=None)
-def _enable_custom_widget_manager() -> None:
+def _enable_custom_widget_manager_once() -> None:
     # Enable custom widgets manager so that our widgets display in Colab
     # https://github.com/googlecolab/colabtools/issues/498#issuecomment-998308485
     sys.modules["google.colab.output"].enable_custom_widget_manager()
@@ -129,7 +129,7 @@ def get_repr_metadata() -> dict:
     if "google.colab.output" not in sys.modules:
         return {}
 
-    _enable_custom_widget_manager()
+    _enable_custom_widget_manager_once()
     url = sys.modules["google.colab.output"]._installed_url
 
     if url is None:

--- a/anywidget/_util.py
+++ b/anywidget/_util.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import sys
+from functools import lru_cache
 from typing import Any
 
 _BINARY_TYPES = (memoryview, bytearray, bytes)
+_WIDGET_MIME_TYPE = "application/vnd.jupyter.widget-view+json"
 
 # next 3 functions vendored with modifications from ipywidgets
 # BSD-3-Clause
@@ -105,3 +108,31 @@ def put_buffers(
         for key in buffer_path[:-1]:
             obj = obj[key]
         obj[buffer_path[-1]] = buffer
+
+
+@lru_cache(maxsize=None)
+def _enable_custom_widget_manager() -> None:
+    # Enable custom widgets manager so that our widgets display in Colab
+    # https://github.com/googlecolab/colabtools/issues/498#issuecomment-998308485
+    sys.modules["google.colab.output"].enable_custom_widget_manager()
+
+
+def get_repr_metadata() -> dict:
+    """Creates metadata dict for _repr_mimebundle_.
+
+    If in Google Colab, enables custom widgets as a side effect
+    and injects the `custom_widget_manager` metadata for more
+    consistent rendering.
+
+    See https://github.com/manzt/anywidget/issues/63#issuecomment-1427194000.
+    """
+    if "google.colab.output" not in sys.modules:
+        return {}
+
+    _enable_custom_widget_manager()
+    url = sys.modules["google.colab.output"]._installed_url
+
+    if url is None:
+        return {}
+
+    return {_WIDGET_MIME_TYPE: {"colab": {"custom_widget_manager": {"url": url}}}}

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -5,7 +5,11 @@ from typing import Any
 import ipywidgets
 import traitlets.traitlets as t
 
-from ._util import get_repr_metadata
+from ._util import (
+    enable_custom_widget_manager_once,
+    get_repr_metadata,
+    in_colab,
+)
 from ._version import __version__
 
 _ANYWIDGET_ID_KEY = "_anywidget_id"
@@ -59,8 +63,8 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
 
         self.add_traits(**anywidget_traits)
 
-        # Enables the custom widget manager
-        get_repr_metadata()
+        if in_colab():
+            enable_custom_widget_manager_once()
 
     if hasattr(ipywidgets.DOMWidget, "_repr_mimebundle_"):
         # ipywidgets v8

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -59,14 +59,10 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
 
         self.add_traits(**anywidget_traits)
 
-        # Enables custom widget manager if we are in Colab
+        # Enables the custom widget manager
         get_repr_metadata()
 
-        # Monkey-patch _repr_mimebundle_ to include metadata necessary for Colab
-        if hasattr(super(), "_repr_mimebundle_"):
-            original = super()._repr_mimebundle_
-
-            def _repr_mimebundle_(**kwargs: dict) -> tuple[dict, dict]:
-                return original(**kwargs) or {}, get_repr_metadata()
-
-            self._repr_mimebundle_ = _repr_mimebundle_
+    if hasattr(ipywidgets.DOMWidget, "_repr_mimebundle_"):
+        # ipywidgets v8
+        def _repr_mimebundle_(self, **kwargs) -> tuple[None | dict, dict]:
+            return super()._repr_mimebundle_(**kwargs), get_repr_metadata()

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any
 
 import ipywidgets
 import traitlets.traitlets as t
@@ -59,10 +59,14 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
 
         self.add_traits(**anywidget_traits)
 
-    def _repr_mimebundle_(self, **kwargs: Sequence[str]) -> tuple[dict, dict]:
-        if hasattr(super(), "_repr_mimebundle_"):
-            data = super()._repr_mimebundle_(**kwargs) or {}
-        else:
-            data = {}
+        # Enables custom widget manager if we are in Colab
+        get_repr_metadata()
 
-        return data, get_repr_metadata()
+        # Monkey-patch _repr_mimebundle_ to include metadata necessary for Colab
+        if hasattr(super(), "_repr_mimebundle_"):
+            original = self._repr_mimebundle_
+
+            def _repr_mimebundle_(**kwargs: dict) -> tuple[dict, dict]:
+                return original(**kwargs) or {}, get_repr_metadata()
+
+            self._repr_mimebundle_ = _repr_mimebundle_  # type: ignore

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -60,7 +60,7 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
         self.add_traits(**anywidget_traits)
 
     def _repr_mimebundle_(self, **kwargs: Sequence[str]) -> tuple[dict, dict]:
-        if hasattr(super(), "repr_mimebundle"):
+        if hasattr(super(), "_repr_mimebundle_"):
             data = super()._repr_mimebundle_(**kwargs) or {}
         else:
             data = {}

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -64,9 +64,9 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
 
         # Monkey-patch _repr_mimebundle_ to include metadata necessary for Colab
         if hasattr(super(), "_repr_mimebundle_"):
-            original = self._repr_mimebundle_
+            original = super()._repr_mimebundle_
 
             def _repr_mimebundle_(**kwargs: dict) -> tuple[dict, dict]:
                 return original(**kwargs) or {}, get_repr_metadata()
 
-            self._repr_mimebundle_ = _repr_mimebundle_  # type: ignore
+            self._repr_mimebundle_ = _repr_mimebundle_

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -64,5 +64,5 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
 
     if hasattr(ipywidgets.DOMWidget, "_repr_mimebundle_"):
         # ipywidgets v8
-        def _repr_mimebundle_(self, **kwargs) -> tuple[None | dict, dict]:
+        def _repr_mimebundle_(self, **kwargs: dict) -> tuple[None | dict, dict]:
             return super()._repr_mimebundle_(**kwargs), get_repr_metadata()

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Sequence
 
 import ipywidgets

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -55,7 +55,9 @@ def test_descriptor(mock_comm: MagicMock) -> None:
     repr_method = foo._repr_mimebundle_  # the comm is created here
     mock_comm.send.assert_called_once()
     assert isinstance(repr_method, ReprMimeBundle)
-    assert _JUPYTER_MIME in repr_method()  # we can call it as usual
+    bundle = repr_method()
+    assert _JUPYTER_MIME in bundle[0]  # we can call it as usual
+    assert len(bundle[1]) == 0
 
     # test that the comm sends update messages
     foo._repr_mimebundle_.send_state({"value"})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,12 @@
-from anywidget._util import put_buffers, remove_buffers
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from anywidget._util import (
+    get_repr_metadata,
+    put_buffers,
+    remove_buffers,
+)
 
 
 def test_remove_and_put_buffers():
@@ -58,3 +66,32 @@ def test_remove_and_put_buffers():
     # tuple to a list
     state_before["z"] = list(state_before["z"])
     assert state_before == state
+
+
+def test_enables_widget_manager_in_colab(monkeypatch: pytest.MonkeyPatch):
+    mock = MagicMock()
+    monkeypatch.setitem(sys.modules, "google.colab.output", mock)
+    get_repr_metadata()
+    get_repr_metadata()
+    assert mock.enable_custom_widget_manager.assert_called_once
+
+
+def test_get_metadata(monkeypatch: pytest.MonkeyPatch):
+    meta = get_repr_metadata()
+    assert meta == {}
+
+    mock = MagicMock()
+    mock._installed_url = None
+    monkeypatch.setitem(sys.modules, "google.colab.output", mock)
+    meta = get_repr_metadata()
+    assert meta == {}
+
+    mock = MagicMock()
+    mock._installed_url = "foo"
+    monkeypatch.setitem(sys.modules, "google.colab.output", mock)
+    meta = get_repr_metadata()
+    assert meta == {
+        "application/vnd.jupyter.widget-view+json": {
+            "colab": {"custom_widget_manager": {"url": "foo"}}
+        }
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,13 +81,13 @@ def test_get_metadata(monkeypatch: pytest.MonkeyPatch):
     assert meta == {}
 
     mock = MagicMock()
-    mock._installed_url = None
+    mock._widgets._installed_url = None
     monkeypatch.setitem(sys.modules, "google.colab.output", mock)
     meta = get_repr_metadata()
     assert meta == {}
 
     mock = MagicMock()
-    mock._installed_url = "foo"
+    mock._widgets._installed_url = "foo"
     monkeypatch.setitem(sys.modules, "google.colab.output", mock)
     meta = get_repr_metadata()
     assert meta == {

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,8 +1,12 @@
 import json
 import pathlib
+import sys
+from unittest.mock import MagicMock
 
 import anywidget
+import pytest
 import traitlets.traitlets as t
+from anywidget._util import _WIDGET_MIME_TYPE
 from anywidget.widget import DEFAULT_ESM
 
 
@@ -103,3 +107,27 @@ def test_infer_traitlets_partial():
     assert w.has_trait("_css")
     assert w._css == CSS
     assert w.trait_metadata("_css", "sync")
+
+
+def test_patched_repr(monkeypatch: pytest.MonkeyPatch):
+    w = anywidget.AnyWidget()
+    bundle = w._repr_mimebundle_()
+    assert _WIDGET_MIME_TYPE in bundle[0]
+    assert bundle[1] == {}
+
+    w = anywidget.AnyWidget()
+    bundle = w._repr_mimebundle_()
+
+    assert _WIDGET_MIME_TYPE in bundle[0]
+    assert bundle[1] == {}
+
+    mock = MagicMock()
+    mock._installed_url = "foo"
+    monkeypatch.setitem(sys.modules, "google.colab.output", mock)
+
+    w = anywidget.AnyWidget()
+    assert mock.enable_custom_widget_manager.called_once
+
+    bundle = w._repr_mimebundle_()
+    assert _WIDGET_MIME_TYPE in bundle[0]
+    assert _WIDGET_MIME_TYPE in bundle[1]

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,12 +1,8 @@
 import json
 import pathlib
-import sys
-from unittest.mock import MagicMock
 
 import anywidget
-import pytest
 import traitlets.traitlets as t
-from anywidget._util import _WIDGET_MIME_TYPE
 from anywidget.widget import DEFAULT_ESM
 
 
@@ -107,28 +103,3 @@ def test_infer_traitlets_partial():
     assert w.has_trait("_css")
     assert w._css == CSS
     assert w.trait_metadata("_css", "sync")
-
-
-def test_enables_widget_manager_in_colab(monkeypatch: pytest.MonkeyPatch):
-    mock = MagicMock()
-    monkeypatch.setitem(sys.modules, "google.colab.output", mock)
-
-    anywidget.AnyWidget()._repr_mimebundle_()
-    anywidget.AnyWidget()._repr_mimebundle_()
-    assert mock.enable_custom_widget_manager.assert_called_once
-
-
-def test_injects_colab_meta(monkeypatch: pytest.MonkeyPatch):
-    mock = MagicMock()
-    monkeypatch.setitem(sys.modules, "google.colab.output", mock)
-
-    w = anywidget.AnyWidget()
-    bundle = w._repr_mimebundle_()
-    assert _WIDGET_MIME_TYPE in bundle[1]
-    assert "colab" in bundle[1][_WIDGET_MIME_TYPE]
-
-
-def test_empty_meta():
-    w = anywidget.AnyWidget()
-    bundle = w._repr_mimebundle_()
-    assert len(bundle[1]) == 0

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -109,16 +109,10 @@ def test_infer_traitlets_partial():
     assert w.trait_metadata("_css", "sync")
 
 
-def test_patched_repr(monkeypatch: pytest.MonkeyPatch):
+def test_patched_repr_ipywidget_v8(monkeypatch: pytest.MonkeyPatch):
     w = anywidget.AnyWidget()
     bundle = w._repr_mimebundle_()
-    assert _WIDGET_MIME_TYPE in bundle[0]
-    assert bundle[1] == {}
-
-    w = anywidget.AnyWidget()
-    bundle = w._repr_mimebundle_()
-
-    assert _WIDGET_MIME_TYPE in bundle[0]
+    assert bundle[0] and _WIDGET_MIME_TYPE in bundle[0]
     assert bundle[1] == {}
 
     mock = MagicMock()
@@ -129,5 +123,5 @@ def test_patched_repr(monkeypatch: pytest.MonkeyPatch):
     assert mock.enable_custom_widget_manager.called_once
 
     bundle = w._repr_mimebundle_()
-    assert _WIDGET_MIME_TYPE in bundle[0]
+    assert bundle[0] and _WIDGET_MIME_TYPE in bundle[0]
     assert _WIDGET_MIME_TYPE in bundle[1]

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -132,8 +132,3 @@ def test_empty_meta():
     w = anywidget.AnyWidget()
     bundle = w._repr_mimebundle_()
     assert len(bundle[1]) == 0
-
-
-def test_default_no_ipython_display():
-    w = anywidget.AnyWidget()
-    assert not hasattr(w, "")


### PR DESCRIPTION
Implements the more robust solution for supporting colab outlined in #63, but also for `ReprMimeBundle`.
