### PR TITLE
chore: add version script to bump lockfile version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
+          version: npm run version
           # This expects you to have a script called release which does a build for the packages and calls `changeset publish`
           publish: npm run release
         env:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"build:vite-plugin": "esbuild --format=cjs --outfile=dist/vite.cjs vite-plugin.js && cp vite-plugin.js dist/vite.mjs",
 		"prepack": "rm -rf dist && npm run build:nb && mkdir dist && cp anywidget/nbextension/index.js dist/index.js && npm run build:vite-plugin",
 		"clean": "rm -rf dist-python dist anywidget/nbextension/index.js anywidget/labextension/",
+		"version": "changeset version && npm install",
 		"release": "npm run prepack && npm run build:python && changeset publish && twine upload dist-python/*"
 	},
 	"dependencies": {


### PR DESCRIPTION
The current versioning script doesn't also bump the version of `anywidget` in `package-lock.json`. This PR adds a custom version script that calls `npm install` after `changesets version` so that `package.json` and `package-lock.json` stay in sync.
