### PR TITLE
feat: auto infer `FileContents` for valid file paths

### DIFF
--- a/.changeset/green-queens-beam.md
+++ b/.changeset/green-queens-beam.md
@@ -14,6 +14,7 @@ class Counter(anywidget.AnyWidget):
 ```
 
 If a file path for an existing file is detected for `_esm` or `_css`,
-the contents will be read from disk automatically. If the path is outside
-of `site-packages`, the file will be watched in a background thread and
-changes will be emitted widget instance for live reloads.
+the contents will be read from disk automatically. If the resolved
+path is _not_ in `site-packages` (i.e., likely a development install), a
+background thread will start watching for file changes and push updates
+to the front end.

--- a/.changeset/green-queens-beam.md
+++ b/.changeset/green-queens-beam.md
@@ -1,0 +1,19 @@
+---
+"anywidget": patch
+---
+
+feat: auto-create (and watch) `FileContents` for valid file paths
+
+```python
+import anywidget
+import traitlets
+
+class Counter(anywidget.AnyWidget):
+    _esm = "index.js"
+    value = traitlets.Int(0).tag(sync=True)
+```
+
+If a file path for an existing file is detected for `_esm` or `_css`,
+the contents will be read from disk automatically. If the path is outside
+of `site-packages`, the file will be watched in a background thread and
+changes will be emitted widget instance for live reloads.

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -25,9 +25,18 @@ import weakref
 from dataclasses import asdict, is_dataclass
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, cast, overload
 
-from ._util import get_repr_metadata, put_buffers, remove_buffers
+from ._file_contents import FileContents
+from ._util import (
+    _ANYWIDGET_ID_KEY,
+    _DEFAULT_ESM,
+    _ESM_KEY,
+    _WIDGET_MIME_TYPE,
+    get_repr_metadata,
+    put_buffers,
+    remove_buffers,
+    try_file_contents,
+)
 from ._version import __version__
-from .widget import DEFAULT_ESM
 
 if TYPE_CHECKING:  # pragma: no cover
     import psygnal
@@ -43,12 +52,9 @@ if TYPE_CHECKING:  # pragma: no cover
 
 __all__ = ["MimeBundleDescriptor", "ReprMimeBundle"]
 
-_JUPYTER_MIME = "application/vnd.jupyter.widget-view+json"
 _REPR_ATTR = "_repr_mimebundle_"
 _STATE_GETTER_NAME = "_get_anywidget_state"
 _STATE_SETTER_NAME = "_set_anywidget_state"
-_ANYWIDGET_ID_KEY = "_anywidget_id"
-_ESM_KEY = "_esm"
 
 _PROTOCOL_VERSION_MAJOR = 2
 _PROTOCOL_VERSION_MINOR = 1
@@ -130,7 +136,7 @@ class MimeBundleDescriptor:
         explicitly called.
     **extra_state : Any, optional
         Any extra state that should be sent to the javascript view (for example,
-        for the `_esm` anywidget field.)  By default, `{'_esm': DEFAULT_ESM}` is added
+        for the `_esm` anywidget field.)  By default, `{'_esm': _DEFAULT_ESM}` is added
         to the state.
 
     Examples
@@ -157,11 +163,17 @@ class MimeBundleDescriptor:
         autodetect_observer: bool = True,
         **extra_state: Any,
     ) -> None:
-        extra_state.setdefault(_ESM_KEY, DEFAULT_ESM)
+        extra_state.setdefault(_ESM_KEY, _DEFAULT_ESM)
         self._extra_state = extra_state
         self._name = _REPR_ATTR
         self._follow_changes = follow_changes
         self._autodetect_observer = autodetect_observer
+
+        for k, v in self._extra_state.items():
+            # TODO: use := when we drop python 3.7
+            file_contents = try_file_contents(v)
+            if file_contents is not None:
+                self._extra_state[k] = file_contents
 
     def __set_name__(self, owner: type, name: str) -> None:
         """Called when this descriptor is assigned to an attribute on a class.
@@ -263,7 +275,7 @@ class ReprMimeBundle:
         extra_state: dict[str, Any] | None = None,
     ):
         self._autodetect_observer = autodetect_observer
-        self._extra_state = extra_state or {}
+        self._extra_state = (extra_state or {}).copy()
         self._extra_state.setdefault(_ANYWIDGET_ID_KEY, _anywidget_id(obj))
 
         try:
@@ -286,6 +298,15 @@ class ReprMimeBundle:
         # figure out what type of object we're working with, and how it "get state".
         self._get_state = determine_state_getter(obj)
         self._set_state = determine_state_setter(obj)
+
+        for key, value in self._extra_state.items():
+            if isinstance(value, FileContents):
+                self._extra_state[key] = str(value)
+
+                @value.changed.connect
+                def _on_change(new_contents: str, key: str = key) -> None:
+                    self._extra_state[key] = new_contents
+                    self.send_state(key)
 
     def _on_obj_deleted(self, ref: weakref.ReferenceType | None = None) -> None:
         """Called when the python object is deleted."""
@@ -361,7 +382,7 @@ class ReprMimeBundle:
         # (i.e. the comm knows how to represent itself as a mimebundle)
         data = {
             "text/plain": repr(self),
-            _JUPYTER_MIME: {
+            _WIDGET_MIME_TYPE: {
                 "version_major": _PROTOCOL_VERSION_MAJOR,
                 "version_minor": _PROTOCOL_VERSION_MINOR,
                 "model_id": self._comm.comm_id,

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -444,27 +444,6 @@ class ReprMimeBundle:
             with contextlib.suppress(Exception):
                 self._disconnectors.pop()()
 
-    def _send_hmr_update(self, esm: str | None = None, css: str | None = None) -> None:
-        """Send new ESM or CSS for front end to load and re-render the current views.
-
-        Parameters
-        ----------
-        esm : string, optional
-            anywidget front-end JavaScript code. Can be raw text or URL.
-        css : string, optional
-            anywidget front-end CSS code. Can be raw text or URL.
-        """
-        update = {}
-
-        if esm is not None:
-            update["_esm"] = esm
-
-        if css is not None:
-            update["_css"] = css
-
-        self._extra_state.update(update)
-        self.send_state(update.keys())
-
 
 # ------------- Helper function --------------
 

--- a/anywidget/_util.py
+++ b/anywidget/_util.py
@@ -156,6 +156,7 @@ def try_file_contents(x: Any) -> FileContents | None:
 
     maybe_path = pathlib.Path(x)
 
+    # Could raise OSError if not a path and exceeds max path length
     with contextlib.suppress(OSError):
         maybe_path = pathlib.Path(maybe_path).resolve().absolute()
         if maybe_path.is_file():

--- a/anywidget/_util.py
+++ b/anywidget/_util.py
@@ -10,6 +10,21 @@ from ._file_contents import FileContents
 
 _BINARY_TYPES = (memoryview, bytearray, bytes)
 _WIDGET_MIME_TYPE = "application/vnd.jupyter.widget-view+json"
+_ANYWIDGET_ID_KEY = "_anywidget_id"
+_ESM_KEY = "_esm"
+_CSS_KEY = "_css"
+_DEFAULT_ESM = """
+export function render(view) {
+  console.log("Dev note: No _esm defined for this widget:", view);
+  let url = "https://anywidget.dev/en/getting-started/";
+  view.el.innerHTML = `<p>
+    <strong>Dev note</strong>:
+    <a href='${url}' target='blank'>Implement an <code>_esm</code> attribute</a>
+    on AnyWidget subclass <code>${view.model.get('_anywidget_id')}</code>
+    to customize this widget.
+  </p>`;
+}
+"""
 
 # next 3 functions vendored with modifications from ipywidgets
 # BSD-3-Clause

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -74,7 +74,7 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
         if in_colab():
             enable_custom_widget_manager_once()
 
-    def __init_subclass__(cls, **kwargs) -> None:
+    def __init_subclass__(cls, **kwargs: dict) -> None:
         """Coerces _esm and _css to FileContents if they are files."""
         super().__init_subclass__(**kwargs)
         for key in (_ESM_KEY, _CSS_KEY) & cls.__dict__.keys():

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -7,28 +7,16 @@ import traitlets.traitlets as t
 
 from ._file_contents import FileContents
 from ._util import (
+    _ANYWIDGET_ID_KEY,
+    _CSS_KEY,
+    _DEFAULT_ESM,
+    _ESM_KEY,
     enable_custom_widget_manager_once,
     get_repr_metadata,
     in_colab,
     try_file_contents,
 )
 from ._version import __version__
-
-_ANYWIDGET_ID_KEY = "_anywidget_id"
-_ESM_KEY = "_esm"
-_CSS_KEY = "_css"
-DEFAULT_ESM = """
-export function render(view) {
-  console.log("Dev note: No _esm defined for this widget:", view);
-  let url = "https://anywidget.dev/en/getting-started/";
-  view.el.innerHTML = `<p>
-    <strong>Dev note</strong>:
-    <a href='${url}' target='blank'>Implement an <code>_esm</code> attribute</a>
-    on AnyWidget subclass <code>${view.model.get('_anywidget_id')}</code>
-    to customize this widget.
-  </p>`;
-}
-"""
 
 
 class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
@@ -60,7 +48,7 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
 
         # show default _esm if not defined
         if not hasattr(self, _ESM_KEY):
-            anywidget_traits[_ESM_KEY] = t.Unicode(DEFAULT_ESM).tag(sync=True)
+            anywidget_traits[_ESM_KEY] = t.Unicode(_DEFAULT_ESM).tag(sync=True)
 
         # TODO: a better way to uniquely identify this subclasses?
         # We use the fully-qualified name to get an id which we

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -78,7 +78,9 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
         """Coerces _esm and _css to FileContents if they are files."""
         super().__init_subclass__(**kwargs)
         for key in (_ESM_KEY, _CSS_KEY) & cls.__dict__.keys():
-            if file_contents := try_file_contents(getattr(cls, key)):
+            # TODO: Upgrate to := when we drop Python 3.7
+            file_contents = try_file_contents(getattr(cls, key))
+            if file_contents:
                 setattr(cls, key, file_contents)
 
     if hasattr(ipywidgets.DOMWidget, "_repr_mimebundle_"):

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -83,47 +83,6 @@ def test_descriptor(mock_comm: MagicMock) -> None:
     mock_comm.send.assert_called()
 
 
-def test_descriptor_sends_hmr_update(mock_comm: MagicMock) -> None:
-    """Test that descriptor sends custom anywidget HMR update to front end."""
-
-    esm = "export function render(view) {}"
-    css = "h1 { }"
-
-    class Foo:
-        _repr_mimebundle_ = MimeBundleDescriptor(autodetect_observer=False)
-        value: int = 0
-
-        def _get_anywidget_state(self):
-            return {"value": self.value}
-
-    foo = Foo()
-
-    foo._repr_mimebundle_._send_hmr_update(esm=esm, css=css)
-    mock_comm.send.assert_called_with(
-        data={
-            "method": "update",
-            "state": {"_esm": esm, "_css": css},
-            "buffer_paths": [],
-        },
-        buffers=[],
-    )
-
-    foo._repr_mimebundle_._send_hmr_update(esm=esm)
-    mock_comm.send.assert_called_with(
-        data={"method": "update", "state": {"_esm": esm}, "buffer_paths": []},
-        buffers=[],
-    )
-
-    foo._repr_mimebundle_._send_hmr_update(css=css)
-    mock_comm.send.assert_called_with(
-        data={"method": "update", "state": {"_css": css}, "buffer_paths": []},
-        buffers=[],
-    )
-
-    foo._repr_mimebundle_._send_hmr_update()
-    mock_comm.send.assert_not_called
-
-
 def test_state_setter(mock_comm: MagicMock):
     """Test that `_set_anywidget_state` is used when present."""
     mock = MagicMock()

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -1,3 +1,5 @@
+import pathlib
+import time
 import weakref
 from dataclasses import dataclass
 from typing import ClassVar
@@ -5,12 +7,15 @@ from unittest.mock import MagicMock, patch
 
 import anywidget._descriptor
 import pytest
+import watchfiles
 from anywidget._descriptor import (
     _COMMS,
-    _JUPYTER_MIME,
+    _WIDGET_MIME_TYPE,
     MimeBundleDescriptor,
     ReprMimeBundle,
 )
+from anywidget._file_contents import FileContents
+from watchfiles import Change
 
 
 class MockComm(MagicMock):
@@ -56,7 +61,7 @@ def test_descriptor(mock_comm: MagicMock) -> None:
     mock_comm.send.assert_called_once()
     assert isinstance(repr_method, ReprMimeBundle)
     bundle = repr_method()
-    assert _JUPYTER_MIME in bundle[0]  # we can call it as usual
+    assert _WIDGET_MIME_TYPE in bundle[0]  # we can call it as usual
     assert len(bundle[1]) == 0
 
     # test that the comm sends update messages
@@ -279,3 +284,54 @@ def test_descriptor_with_traitlets(mock_comm: MagicMock):
     foo.value = 5
     mock_comm.assert_not_called()
     assert not repr_obj._disconnectors
+
+
+def test_infer_file_contents(mock_comm: MagicMock, tmp_path: pathlib.Path) -> None:
+    """Test that the file contents are inferred from the file path."""
+
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+
+    esm = site_packages / "foo.js"
+    esm.write_text(
+        "export function render(view) { view.el.innerText = 'Hello, world'; }"
+    )
+
+    class Foo:
+        _repr_mimebundle_ = MimeBundleDescriptor(_esm=esm, autodetect_observer=False)
+        value: int = 1
+
+        def _get_anywidget_state(self):
+            return {"value": self.value}
+
+    file_contents = Foo._repr_mimebundle_._extra_state["_esm"]
+    assert isinstance(file_contents, FileContents)
+    assert file_contents._background_thread is None
+
+    foo = Foo()
+    assert foo._repr_mimebundle_._extra_state["_esm"] == esm.read_text()
+
+    def mock_file_events():
+        esm.write_text("blah")
+        # write to file
+        changes = set()
+        changes.add((Change.modified, str(esm)))
+        yield changes
+        # delete the file
+        changes = set()
+        changes.add((Change.deleted, str(esm)))
+        yield changes
+
+    with patch.object(watchfiles, "watch") as mock_watch:
+        mock_watch.return_value = mock_file_events()
+        file_contents.watch_in_thread()
+
+    while (
+        file_contents._background_thread and file_contents._background_thread.is_alive()
+    ):
+        time.sleep(0.01)
+
+    mock_comm.send.assert_called_with(
+        data={"method": "update", "state": {"_esm": "blah"}, "buffer_paths": []},
+        buffers=[],
+    )

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -295,6 +295,7 @@ def test_infer_file_contents(mock_comm: MagicMock, tmp_path: pathlib.Path) -> No
         buffers=[],
     )
 
+
 def test_explicit_file_contents(tmp_path: pathlib.Path) -> None:
     """Test that the file contents are inferred from the file path."""
 
@@ -313,7 +314,6 @@ def test_explicit_file_contents(tmp_path: pathlib.Path) -> None:
     file_contents = Foo._repr_mimebundle_._extra_state["bar"]
     assert file_contents == bar
     assert file_contents._background_thread is None
-
 
     foo = Foo()
     assert foo._repr_mimebundle_._extra_state["bar"] == path.read_text()

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -9,8 +9,7 @@ import pytest
 import traitlets.traitlets as t
 import watchfiles
 from anywidget._file_contents import FileContents
-from anywidget._util import _WIDGET_MIME_TYPE
-from anywidget.widget import DEFAULT_ESM
+from anywidget._util import _DEFAULT_ESM, _WIDGET_MIME_TYPE
 from watchfiles import Change
 
 
@@ -44,7 +43,7 @@ def test_default_esm():
     w = Widget()
 
     assert w.has_trait("_esm")
-    assert w._esm == DEFAULT_ESM
+    assert w._esm == _DEFAULT_ESM
 
 
 def test_creates_fully_qualified_identifier():

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -180,6 +180,8 @@ def test_infer_file_contents(tmp_path: pathlib.Path):
 
     assert w._css == css.read_text()
 
+    Widget._esm.stop_thread()
+
 
 def test_missing_file_no_infer(tmp_path: pathlib.Path):
     esm = tmp_path / "foo.js"

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -180,6 +180,7 @@ def test_infer_file_contents(tmp_path: pathlib.Path):
 
     assert w._css == css.read_text()
 
+    # need to teardown the thread for CI
     Widget._esm.stop_thread()
 
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -131,7 +131,7 @@ def test_patched_repr_ipywidget_v8(monkeypatch: pytest.MonkeyPatch):
     assert _WIDGET_MIME_TYPE in bundle[1]
 
 
-def test_infer_file_contents(tmp_path):
+def test_infer_file_contents(tmp_path: pathlib.Path):
     esm = tmp_path / "foo.js"
     esm.write_text(
         "export function render(view) { view.el.innerText = 'Hello, world'; }"
@@ -179,3 +179,22 @@ def test_infer_file_contents(tmp_path):
         time.sleep(0.01)
 
     assert w._css == css.read_text()
+
+
+def test_missing_file_no_infer(tmp_path: pathlib.Path):
+    esm = tmp_path / "foo.js"
+    css = str(tmp_path / "styles.css")
+
+    class Widget(anywidget.AnyWidget):
+        _esm = esm
+        _css = css
+
+    assert isinstance(Widget._esm, pathlib.Path)
+    assert Widget._esm == esm
+    assert isinstance(Widget._css, str)
+    assert Widget._css == css
+
+    w = Widget()
+
+    assert w._esm == str(tmp_path / "foo.js")
+    assert w._css == css

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -200,3 +200,19 @@ def test_missing_file_no_infer(tmp_path: pathlib.Path):
 
     assert w._esm == str(tmp_path / "foo.js")
     assert w._css == css
+
+
+def test_explicit_file_contents(tmp_path: pathlib.Path):
+    path = tmp_path / "foo.js"
+    path.write_text(
+        "export function render(view) { view.el.innerText = 'Hello, world'; }"
+    )
+    esm = FileContents(path, start_thread=False)
+
+    class Widget(anywidget.AnyWidget):
+        _esm = esm
+
+    assert Widget._esm == esm
+
+    w = Widget()
+    assert w._esm == path.read_text()


### PR DESCRIPTION
This PR adds a useful feature to auto-create `FileContents` objects from `_esm` or `_css` attributes on anywidget subclasses.

```python
import anywidget
import traitlets

class Counter(anywidget.AnyWidget):
    _esm = "index.js"
    value = traitlets.Int().tag(sync=True)

Counter()
```

A `FileContents` object is only created if the provided `str` or `pathlib.Path` points to an existing file. In addition, the object is set to "watch mode" (spinning up a background thread) if the path is detected outside of `site-packages` (i.e., likely a development install).


EDIT:

This PR now also implements supports detection in the descriptor:

```python
from anywidget._descriptor import MimeBundleDescriptor
from psygnal import evented
from dataclasses import dataclass

@evented
@dataclass
class Counter:
    _repr_mimebundle_ = MimeBundleDescriptor(_esm="index.js")
    count: int = 0

Counter()
```