### PR TITLE
Fix JS variable scope issue

### DIFF
--- a/packages/anywidget/src/widget.js
+++ b/packages/anywidget/src/widget.js
@@ -89,8 +89,9 @@ async function load_esm(esm) {
 	let url = URL.createObjectURL(
 		new Blob([esm], { type: "text/javascript" }),
 	);
+	let widget;
 	try {
-		let widget = await import(/* webpackIgnore: true */ url);
+		widget = await import(/* webpackIgnore: true */ url);
 	} catch (e) {
 		console.log(e);
 		throw e;


### PR DESCRIPTION
There is currently a variable scoping issue in v0.2.2 resulting in the following JS error:

```
Uncaught (in promise) ReferenceError: widget is not defined
```

https://observablehq.com/d/d283036191b4763e