### PR TITLE
fix: add watchfiles as dependency

### DIFF
--- a/.changeset/great-trainers-fetch.md
+++ b/.changeset/great-trainers-fetch.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+fix: add `watchfiles` as a directy dependency

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Learn more in
 may be installed with `pip`:
 
 ```bash
-pip install "anywidget[dev]"
+pip install anywidget
 ```
 
 It is also available on

--- a/docs/src/pages/blog/anywidget-02.md
+++ b/docs/src/pages/blog/anywidget-02.md
@@ -13,7 +13,7 @@ _TL;DR: **anywidget** v0.2 brings modern web development to Jupyter. You can now
 use a **file path** to enable **anywidget**'s integrated Hot Module Replacement (HMR):_
 
 ```sh
-pip install --upgrade "anywidget[dev]"
+pip install --upgrade anywidget
 ```
 
 ```python
@@ -193,7 +193,7 @@ to allow for the special JSX syntax (e.g., `<App />`).
 To start using **anywidget** v0.2, upgrade your package using pip:
 
 ```sh
-pip install --upgrade "anywidget[dev]"
+pip install --upgrade anywidget
 ```
 
 I encourage you to explore the new features in **anywidget** v0.2 and experience the

--- a/docs/src/pages/en/getting-started.mdx
+++ b/docs/src/pages/en/getting-started.mdx
@@ -28,7 +28,7 @@ ecosystem, allowing your widget to run automatically in **Jupyter Notebooks**,
 ## Example
 
 ```
-pip install "anywidget[dev]"
+pip install anywidget
 ```
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "importlib-metadata ; python_version < '3.8'",
     "typing-extensions>=4.2.0",
     "psygnal>=0.8.1",
+    "watchfiles>=0.18.0",
 ]
 
 [project.optional-dependencies]
@@ -28,7 +29,6 @@ test = [
     "ruff",
 ]
 dev = [
-    "watchfiles",
     "ipykernel",
 ]
 


### PR DESCRIPTION
Right now, we raise an exception if one starts developing a widget locally but doesn't have `watchfiles` installed.

Requiring developers to remember to install optional dev dependencies (i.e.,`pip install "anywidget[dev]"`) is kind of annoying, and it's a pretty minimal dependency. This PR adds `watchfiles` as a direct dependency so developers can use `pip install anywidget` and get started without any hiccups.


As an alternative, we could add a warning rather rather than raising an exception, notifying the developer that "watchfiles" must be installed to enable anywidget's live development features, but still load the file the first time. I think adding the dependency is more simple solution, but am open to alternatives.