### PR TITLE
feat: add experimental module with decorator

### DIFF
--- a/.changeset/pretty-rockets-behave.md
+++ b/.changeset/pretty-rockets-behave.md
@@ -1,0 +1,18 @@
+---
+"anywidget": patch
+---
+
+feat: Add `anywidget.experimental` with simple decorator
+
+```python
+import dataclasses
+import psygnal
+
+from anywidget.experimental import widget
+
+@widget(esm="index.js")
+@psygnal.evented
+@dataclasses.dataclass
+class Counter:
+    value: int = 0
+```

--- a/anywidget/experimental.py
+++ b/anywidget/experimental.py
@@ -10,7 +10,12 @@ __all__ = ["widget", "MimeBundleDescriptor"]
 ModelT = typing.TypeVar("ModelT")
 
 
-def widget(*, esm: str | pathlib.Path, css: None | str | pathlib.Path = None, **kwargs):
+def widget(
+    *,
+    esm: str | pathlib.Path,
+    css: None | str | pathlib.Path = None,
+    **kwargs: typing.Any,
+) -> typing.Callable[[ModelT], ModelT]:
     """Decorator to register a widget class as a mimebundle.
 
     Parameters

--- a/anywidget/experimental.py
+++ b/anywidget/experimental.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pathlib
+import typing
+
+from ._descriptor import MimeBundleDescriptor
+
+__all__ = ["widget", "MimeBundleDescriptor"]
+
+ModelT = typing.TypeVar("ModelT")
+
+def widget(
+    *, esm: str | pathlib.Path, css: None | str | pathlib.Path = None, **kwargs
+):
+    """Decorator to register a widget class as a mimebundle.
+
+    Parameters
+    ----------
+    esm : str | pathlib.Path
+        The path or contents of an ES Module for the widget.
+    css : None | str | pathlib.Path, optional
+        The path or contents of a CSS file for the widget.
+    **kwargs
+        Additional keyword arguments to pass to the
+
+    Returns
+    -------
+    Callable
+        A decorator that registers the widget class as a mimebundle.
+    """
+    kwargs["_esm"] = esm
+    if css is not None:
+        kwargs["_css"] = css
+
+    def _decorator(cls: ModelT) -> ModelT:
+        setattr(cls, "_repr_mimebundle_", MimeBundleDescriptor(**kwargs))
+        return cls
+
+    return _decorator

--- a/anywidget/experimental.py
+++ b/anywidget/experimental.py
@@ -9,9 +9,8 @@ __all__ = ["widget", "MimeBundleDescriptor"]
 
 ModelT = typing.TypeVar("ModelT")
 
-def widget(
-    *, esm: str | pathlib.Path, css: None | str | pathlib.Path = None, **kwargs
-):
+
+def widget(*, esm: str | pathlib.Path, css: None | str | pathlib.Path = None, **kwargs):
     """Decorator to register a widget class as a mimebundle.
 
     Parameters

--- a/examples/minimal_example.ipynb
+++ b/examples/minimal_example.ipynb
@@ -55,12 +55,14 @@
    "source": [
     "# +++ inline esm +++\n",
     "\n",
+    "\n",
     "class Widget1(anywidget.AnyWidget):\n",
     "    _esm = \"\"\"\n",
     "    export function render(view) {\n",
     "        console.log(\"Hello World 1\")\n",
     "    }\n",
     "    \"\"\"\n",
+    "\n",
     "\n",
     "Widget1()"
    ]
@@ -111,8 +113,10 @@
    "source": [
     "# and now in action!\n",
     "\n",
+    "\n",
     "class Widget2(anywidget.AnyWidget):\n",
     "    _esm = pathlib.Path(\"index.js\")\n",
+    "\n",
     "\n",
     "Widget2()"
    ]

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -1,0 +1,21 @@
+import dataclasses
+
+import psygnal
+from anywidget._descriptor import ReprMimeBundle
+from anywidget.experimental import MimeBundleDescriptor, widget
+
+
+def test_decorator():
+    esm = "export function render(view) {}"
+    css = ".foo { color: red;}"
+
+    @widget(esm=esm, css=css)
+    @psygnal.evented
+    @dataclasses.dataclass
+    class Foo:
+        bar: str = "baz"
+
+    foo = Foo()
+
+    assert isinstance(Foo._repr_mimebundle_, MimeBundleDescriptor) # type: ignore
+    assert isinstance(foo._repr_mimebundle_, ReprMimeBundle) # type: ignore

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -17,5 +17,5 @@ def test_decorator():
 
     foo = Foo()
 
-    assert isinstance(Foo._repr_mimebundle_, MimeBundleDescriptor) # type: ignore
-    assert isinstance(foo._repr_mimebundle_, ReprMimeBundle) # type: ignore
+    assert isinstance(Foo._repr_mimebundle_, MimeBundleDescriptor)  # type: ignore
+    assert isinstance(foo._repr_mimebundle_, ReprMimeBundle)  # type: ignore


### PR DESCRIPTION
Adds the `anywidget.experimental` model with a simple decorator implementation.

```python
import dataclasses
import psygnal

from anywidget.experimental import widget

@widget(esm="index.js")
@psygnal.evented
@dataclasses.dataclass
class Counter:
    value: int = 0
```

```python
import msgspec
import psygnal

from anywidget.experimental import widget

@widget(esm="index.js")
@psygnal.evented
class Counter(msgspec.Struct, weakref=True):
    value: int = 0
```

```python
from psygnal import EventedModel # pydantic

from anywidget.experimental import widget

@widget(esm="index.js")
class Counter(EventedModel):
    value: int = 0
```

In a follow-up PR, I'd like to automatically decorate a class with a model and emitter if undecorated. E.g.,

```python
from anywidget.experimental import widget

@widget(esm="index.js")
class Counter:
  value: int = 0
```

TODO: add unit test