### PR TITLE
fix: forward obj __repr__ for plain/text mimetype

### DIFF
--- a/.changeset/gentle-frogs-pretend.md
+++ b/.changeset/gentle-frogs-pretend.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+fix(descriptor): forward base obj repr for text/plain mimetype

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -382,7 +382,7 @@ class ReprMimeBundle:
         # NOTE: this could conceivably be a method on a Comm subclass
         # (i.e. the comm knows how to represent itself as a mimebundle)
         data = {
-            "text/plain": repr(self),
+            "text/plain": repr(self._obj()),
             _WIDGET_MIME_TYPE: {
                 "version_major": _PROTOCOL_VERSION_MAJOR,
                 "version_minor": _PROTOCOL_VERSION_MINOR,

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -67,6 +67,7 @@ def test_descriptor(mock_comm: MagicMock) -> None:
     """Test that the descriptor decorator makes a comm, and gets/sets state."""
 
     VAL = 1
+    REPR = "FOO"
 
     class Foo:
         _repr_mimebundle_ = MimeBundleDescriptor(autodetect_observer=False)
@@ -74,6 +75,9 @@ def test_descriptor(mock_comm: MagicMock) -> None:
 
         def _get_anywidget_state(self):
             return {"value": self.value}
+
+        def __repr__(self) -> str:
+            return REPR
 
     foo = Foo()
     mock_comm.send.assert_not_called()  # we haven't yet created a comm object
@@ -94,6 +98,9 @@ def test_descriptor(mock_comm: MagicMock) -> None:
     mock_comm.send.reset_mock()
     mock_comm.handle_msg({"content": {"data": {"method": "request_state"}}})
     mock_comm.send.assert_called()
+
+    # uses the base class repr for plain text
+    assert foo._repr_mimebundle_()[0]["text/plain"] == REPR
 
 
 def test_state_setter(mock_comm: MagicMock):


### PR DESCRIPTION
```python
@widget(esm="index.js")
@psygnal.evented
@dataclasses.dataclass
class Counter:
    value: int = 0
```

Previously (in IPython):

```python
In [1]: Counter()
# Out[1]: <anywidget._descriptor.ReprMimeBundle object at 0x108b98650>
```


Now:

```python
In [1]: Counter()
# Out[1]: Counter(value=0)
```