### PR TITLE
fix: Specify UTF-8 Encoding in `FileContents.__str__`

### DIFF
--- a/.changeset/selfish-kids-grin.md
+++ b/.changeset/selfish-kids-grin.md
@@ -1,0 +1,7 @@
+---
+"anywidget": patch
+---
+
+fix: Specify UTF-8 encoding in `FileContents.__str__`
+
+Fixes an `UnicodeDecodeError` observed on Windows when special characters are present in `_esm` or `_css` elements of a widget.

--- a/anywidget/_file_contents.py
+++ b/anywidget/_file_contents.py
@@ -89,5 +89,5 @@ class FileContents:
 
     def __str__(self) -> str:
         if self._contents is None:
-            self._contents = self._path.read_text()
+            self._contents = self._path.read_text(encoding="utf-8")
         return self._contents


### PR DESCRIPTION
Fixes #134
