### PR TITLE
feat: restrict access to model within render context

### DIFF
--- a/.changeset/moody-games-invite.md
+++ b/.changeset/moody-games-invite.md
@@ -1,0 +1,6 @@
+---
+"anywidget": minor
+"@anywidget/types": minor
+---
+
+feat: restrict backbone model access in render context

--- a/packages/anywidget/src/widget.js
+++ b/packages/anywidget/src/widget.js
@@ -171,7 +171,12 @@ export default function ({ DOMWidgetModel, DOMWidgetView }) {
 					let widget = await load_esm(this.get("_esm"));
 
 					// call any cleanup logic defined by the previous module.
-					await view._anywidget_cached_cleanup();
+					try {
+						await view._anywidget_cached_cleanup();
+					} catch (e) {
+						console.warn("[anywidget] error cleaning up previous module.", e);
+						view._anywidget_cached_cleanup = () => {};
+					}
 
 					// Remove all event listeners added by the user-defined render.
 					this.off(null, null, view);

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,13 +1,21 @@
-import type { DOMWidgetModel, DOMWidgetView } from "@jupyter-widgets/base";
+type MaybePromise<T> = T | Promise<T>;
 
 type ObjectHash = Record<string, any>;
-type MaybePromise<T> = T | Promise<T>;
 type CleanupFn = () => MaybePromise<void>;
 
-export interface AnyModel<T extends ObjectHash = ObjectHash>
-	extends DOMWidgetModel {
+/**
+ * JavaScript events (used in the methods of the Events interface)
+ */
+interface EventHandler {
+	(...args: any[]): void;
+}
+
+export interface AnyModel<T extends ObjectHash = ObjectHash> {
 	get<K extends keyof T>(key: K): T[K];
 	set<K extends keyof T>(key: K, value: T[K]): void;
+	save_changes(): void;
+    on(eventName: string, callback: EventHandler): void;
+    off(eventName?: string | null, callback?: EventHandler | null): void;
 }
 
 export interface RenderContext<Model> {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,8 +14,5 @@
   },
   "scripts": {
     "check": "tsc --noEmit && publint"
-  },
-  "dependencies": {
-    "@jupyter-widgets/base": "^6.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,11 +110,7 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(crypto@1.0.1)(esbuild@0.17.12)
 
-  packages/types:
-    dependencies:
-      '@jupyter-widgets/base':
-        specifier: ^6.0.1
-        version: 6.0.2(crypto@1.0.1)
+  packages/types: {}
 
   packages/vite:
     devDependencies:


### PR DESCRIPTION
Similar to #138

Proxies access to `AnyModel` to automatically provide the `AnyView` instance as context to `model.on` and `model.off`. This ensures that the event handlers will be properly cleaned up when the view is unmounted by anywidget.
