### PR TITLE
feat: add @anywidget/react package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-packages/anywidget/CHANGELOG.md

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,27 @@
+# @anywidget/react
+
+> React utilities for [**anywidget**](https://anywidget.dev)
+
+## Installation
+
+```sh
+npm install @anywidget/react
+```
+
+## Usage
+
+```javascript
+import * as React from "react";
+import { createRender, useModelState } from "@anywidget/react";
+
+function Counter() {
+  let [value, setValue] = useModelState("value");
+  return <button onClick={() => setValue(value + 1)}>count is {count}</button>
+}
+
+export let render = createRender(Counter);
+```
+
+## License
+
+MIT

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -15,8 +15,8 @@ import * as React from "react";
 import { createRender, useModelState } from "@anywidget/react";
 
 function Counter() {
-  let [value, setValue] = useModelState("value");
-  return <button onClick={() => setValue(value + 1)}>count is {count}</button>
+	let [value, setValue] = useModelState("value");
+	return <button onClick={() => setValue(value + 1)}>count is {count}</button>;
 }
 
 export let render = createRender(Counter);

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -6,22 +6,21 @@ import * as ReactDOM from "react-dom/client";
 let ModelContext = React.createContext((/** @type {any} */ (null)));
 
 /**
- * @template {import("@anywidget/types").ObjectHash} Model
- * @template {keyof Model & string} T
- * @param {T} key
+ * @template T
+ *
+ * @param {string} key
  * @returns {[T, (value: T) => void]}
  */
 export function useModelState(key) {
 	let model = React.useContext(ModelContext);
-	if (!model) throw new Error("ModelContext not found");
-
+	if (!model) throw new Error("Model not found");
 	let [value, setValue] = React.useState(model.get(key));
 	React.useEffect(() => {
+		if (!model) return;
 		let callback = () => setValue(model.get(key));
 		model.on(`change:${key}`, callback);
 		return () => model.off(`change:${key}`, callback);
 	}, [model, key]);
-
 	return [value, (value) => {
 		model.set(key, value);
 		model.save_changes();

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -16,7 +16,6 @@ export function useModelState(key) {
 	if (!model) throw new Error("Model not found");
 	let [value, setValue] = React.useState(model.get(key));
 	React.useEffect(() => {
-		if (!model) return;
 		let callback = () => setValue(model.get(key));
 		model.on(`change:${key}`, callback);
 		return () => model.off(`change:${key}`, callback);
@@ -35,7 +34,7 @@ export function useModelState(key) {
  * @returns {import("@anywidget/types").Render}
  */
 export function createRender(Widget) {
-	return function ({ model, el }) {
+	return ({ model, el }) => {
 		let root = ReactDOM.createRoot(el);
 		root.render(
 			React.createElement(

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -1,0 +1,51 @@
+// @ts-check
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
+
+/** @type {React.Context<import("@anywidget/types").AnyModel>} */
+let ModelContext = React.createContext((/** @type {any} */ (null)));
+
+/**
+ * @template {import("@anywidget/types").ObjectHash} Model
+ * @template {keyof Model & string} T
+ * @param {T} key
+ * @returns {[T, (value: T) => void]}
+ */
+export function useModelState(key) {
+	let model = React.useContext(ModelContext);
+	if (!model) throw new Error("ModelContext not found");
+
+	let [value, setValue] = React.useState(model.get(key));
+	React.useEffect(() => {
+		let callback = () => setValue(model.get(key));
+		model.on(`change:${key}`, callback);
+		return () => model.off(`change:${key}`, callback);
+	}, [model, key]);
+
+	return [value, (value) => {
+		model.set(key, value);
+		model.save_changes();
+	}];
+}
+
+/**
+ * @param {React.FC} Widget
+ * @returns {import("@anywidget/types").Render}
+ */
+export function createRender(Widget) {
+	return function ({ model, el }) {
+		let root = ReactDOM.createRoot(el);
+		root.render(
+			React.createElement(
+				React.StrictMode,
+				null,
+				React.createElement(
+					ModelContext.Provider,
+					{ value: model },
+					React.createElement(Widget),
+				),
+			),
+		);
+		return () => root.unmount();
+	};
+}

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 
 /** @type {React.Context<import("@anywidget/types").AnyModel>} */
-let ModelContext = React.createContext((/** @type {any} */ (null)));
+let ModelContext = React.createContext(/** @type {any} */ (null));
 
 /**
  * @template T
@@ -21,10 +21,13 @@ export function useModelState(key) {
 		model.on(`change:${key}`, callback);
 		return () => model.off(`change:${key}`, callback);
 	}, [model, key]);
-	return [value, (value) => {
-		model.set(key, value);
-		model.save_changes();
-	}];
+	return [
+		value,
+		(value) => {
+			model.set(key, value);
+			model.save_changes();
+		},
+	];
 }
 
 /**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@anywidget/react",
+  "type": "module",
+  "version": "0.0.0",
+  "description": "React utilities for anywidget",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --declaration --emitDeclarationOnly --declarationMap --outDir dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "dependencies": {
+    "@anywidget/types": "workspace:^"
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,32 +1,32 @@
 {
-  "name": "@anywidget/react",
-  "type": "module",
-  "version": "0.0.0",
-  "description": "React utilities for anywidget",
-  "main": "index.js",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    }
-  },
-  "scripts": {
-    "build": "tsc --declaration --emitDeclarationOnly --declarationMap --outDir dist",
-    "typecheck": "tsc --noEmit"
-  },
-  "peerDependencies": {
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
-  },
-  "devDependencies": {
-    "@types/react": "^18.2.15",
-    "@types/react-dom": "^18.2.7",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
-  "dependencies": {
-    "@anywidget/types": "workspace:^"
-  }
+	"name": "@anywidget/react",
+	"type": "module",
+	"version": "0.0.0",
+	"description": "React utilities for anywidget",
+	"main": "index.js",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc --declaration --emitDeclarationOnly --declarationMap --outDir dist",
+		"typecheck": "tsc --noEmit"
+	},
+	"peerDependencies": {
+		"@types/react": "^18.0.0",
+		"@types/react-dom": "^18.0.0",
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0"
+	},
+	"devDependencies": {
+		"@types/react": "^18.2.15",
+		"@types/react-dom": "^18.2.7",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0"
+	},
+	"dependencies": {
+		"@anywidget/types": "workspace:^"
+	}
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"moduleResolution": "nodenext",
+		"declaration": true,
+		"outDir": "./dist"
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,25 @@ importers:
         specifier: ^3.6.5
         version: 3.6.5(crypto@1.0.1)(esbuild@0.18.15)
 
+  packages/react:
+    dependencies:
+      "@anywidget/types":
+        specifier: workspace:^
+        version: link:../types
+    devDependencies:
+      "@types/react":
+        specifier: ^18.2.15
+        version: 18.2.15
+      "@types/react-dom":
+        specifier: ^18.2.7
+        version: 18.2.7
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+
   packages/types: {}
 
   packages/vite:
@@ -2780,7 +2799,6 @@ packages:
       {
         integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==,
       }
-    dev: false
 
   /@types/react-dom@18.2.4:
     resolution:
@@ -2790,6 +2808,26 @@ packages:
     dependencies:
       "@types/react": 18.2.8
     dev: false
+
+  /@types/react-dom@18.2.7:
+    resolution:
+      {
+        integrity: sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==,
+      }
+    dependencies:
+      "@types/react": 18.2.15
+    dev: true
+
+  /@types/react@18.2.15:
+    resolution:
+      {
+        integrity: sha512-oEjE7TQt1fFTFSbf8kkNuc798ahTUzn3Le67/PWjE8MAfYAD/qB7O8hSTcromLFqHCt9bcdOg5GXMokzTjJ5SA==,
+      }
+    dependencies:
+      "@types/prop-types": 15.7.5
+      "@types/scheduler": 0.16.3
+      csstype: 3.1.2
+    dev: true
 
   /@types/react@18.2.8:
     resolution:
@@ -2813,7 +2851,6 @@ packages:
       {
         integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==,
       }
-    dev: false
 
   /@types/semver@7.5.0:
     resolution:
@@ -4237,7 +4274,6 @@ packages:
       {
         integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==,
       }
-    dev: false
 
   /csv-generate@3.4.3:
     resolution:
@@ -8454,7 +8490,6 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
-    dev: false
 
   /react-is@18.2.0:
     resolution:
@@ -8935,7 +8970,6 @@ packages:
       }
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /schema-utils@2.7.1:
     resolution:


### PR DESCRIPTION
Follow up to discussion in https://github.com/Octoframes/anywidget-react-vite-test/pull/1#issuecomment-1642180284.

Adds the `@anywidget/react` package that takes care of some boilerplate to connect Jupyter Widget's backbone models
with React.

Usage (without a bundler):

```python
import anywidget
import traitlets

class Counter(anywidget.AnyWidget):
    _esm = """
    import * as React from "https://esm.sh/react@18";
    import { createRender, useModelState } from "https://esm.sh/@anywidget/react?deps=react@18,react-dom@18";
    function Counter() {
      let [value, setValue] = useModelState("value");
      return React.createElement(
        "button",
        { onClick: () => setValue(value + 1) },
        `count is ${value}`
      );
    }
    export let render = createRender(Counter);
    """
    value = traitlets.Int(0).tag(sync=True)

Counter()
```

Usage (with bundler):

```sh
npm i react react-dom @anywidget/react
```

```javascript
import * as React from "react";
import { createRender, useModelState } from "@anywidget/react";

function Counter() {
  let [value, setValue] = useModelState("value");
  return <button onClick={() => setValue(value + 1)}>count is {value}</button>
}

export let render = createRender(Counter);
```

```sh
npx esbuild --bundle --format=esm --outfile=bundle.js counter.jsx
```

```python
import anywidget
import traitlets

class Counter(anywidget.AnyWidget):
    _esm = "bundle.js"
    value = traitlets.Int(0).tag(sync=True)

Counter()
```
