### PR TITLE
feat(anywidget): expose model.widget_manager

### DIFF
--- a/.changeset/selfish-dryers-flow.md
+++ b/.changeset/selfish-dryers-flow.md
@@ -1,0 +1,6 @@
+---
+"anywidget": minor
+"@anywidget/types": minor
+---
+
+feat: expose the `IWidgetManager` from `@jupyter-widgets/base` to render function.

--- a/packages/anywidget/src/widget.js
+++ b/packages/anywidget/src/widget.js
@@ -118,6 +118,7 @@ function extract_context(view) {
 		off(name, callback) {
 			view.model.off(name, callback, view);
 		},
+		widget_manager: view.model.widget_manager,
 	};
 	return { model, el: view.el };
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,3 +1,5 @@
+import type { IWidgetManager } from "@jupyter-widgets/base";
+
 type Awaitable<T> = T | Promise<T>;
 type ObjectHash = Record<string, any>;
 type ChangeEventHandler<Payload> = (_: unknown, value: Payload) => void;
@@ -39,6 +41,7 @@ export interface AnyModel<T extends ObjectHash = ObjectHash> {
 		callbacks?: any,
 		buffers?: ArrayBuffer[] | ArrayBufferView[],
 	): void;
+	widget_manager: IWidgetManager;
 }
 
 export interface RenderContext<T extends ObjectHash = ObjectHash> {


### PR DESCRIPTION
Fixes #193. This can be useful for creating container widgets and avoids exposing more backbone/jupyter-widgets internals.

```python
import anywidget
import ipywidgets as ipw
import traitlets

class Box(anywidget.AnyWidget):
    _esm = """
    async function unpack_models(model_ids, manager) {
        return Promise.all(
            model_ids.map(id => manager.get_model(id.slice("IPY_MODEL_".length)))
        );
    }
    export async function render({ model, el }) {
       let model_ids = model.get("children");
        let children_models = await unpack_models(model_ids, model.widget_manager);
        for (let model of children_models) {
            let child_view = await model.widget_manager.create_view(model);
            el.appendChild(child_view.el);
        }
    }
    """
    children = traitlets.List(trait=traitlets.Instance(ipw.DOMWidget)).tag(sync=True, **ipw.widget_serialization)

Box(children=[ipw.IntProgress(), ipw.IntSlider()])
```

