### PR TITLE
feat(react): add `useModel` hook

### DIFF
--- a/.changeset/lazy-trees-yawn.md
+++ b/.changeset/lazy-trees-yawn.md
@@ -1,0 +1,5 @@
+---
+"@anywidget/react": patch
+---
+
+feat: add 'useModel' hook

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -5,6 +5,12 @@ import * as ReactDOM from "react-dom/client";
 /** @type {React.Context<import("@anywidget/types").AnyModel>} */
 let ModelContext = React.createContext(/** @type {any} */ (null));
 
+export function useModel() {
+	let model = React.useContext(ModelContext);
+	if (!model) throw new Error("Model not found");
+	return model;
+}
+
 /**
  * @template T
  *
@@ -12,8 +18,7 @@ let ModelContext = React.createContext(/** @type {any} */ (null));
  * @returns {[T, (value: T) => void]}
  */
 export function useModelState(key) {
-	let model = React.useContext(ModelContext);
-	if (!model) throw new Error("Model not found");
+	let model = useModel();
 	let [value, setValue] = React.useState(model.get(key));
 	React.useEffect(() => {
 		let callback = () => setValue(model.get(key));


### PR DESCRIPTION
Adds a hook to grab the model. Can be useful to subscribe to custom messages:

```javascript
import * as React from "react";
import { createRender, useModel } from "@anywidget/react";

export let render = createRender(() => {
  let model = useModel();
  let [data, setData] = React.useState(null);

  React.useEffect(() => {
    let callback = (msg) => setData(msg);
    model.on("msg:custom", callback);
    return () => model.off("msg:custom", callback);
  }, [model]);

  if (!data) return null;
  return <pre>JSON.stringify(data)</pre>;
});
```