### PR TITLE
feat: add `@anywidget/svelte` adapter

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,7 @@
 		}
 	},
 	"scripts": {
-		"build": "tsc --declaration --emitDeclarationOnly --declarationMap --outDir dist",
+		"build": "tsc --declaration --emitDeclarationOnly --outDir dist",
 		"typecheck": "tsc --noEmit"
 	},
 	"peerDependencies": {

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,8 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"moduleResolution": "nodenext",
-		"declaration": true,
-		"outDir": "./dist"
-	}
+	"extends": "../../tsconfig.json"
 }

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -36,6 +36,12 @@ export let render = createRender(Counter);
 rollup -p @rollup/plugin-node-resolve -p rollup-plugin-svelte index.js > bundle.js
 ```
 
+## Acknowledgements
+
+Special thanks to [Daria Vasyukova](https://github.com/gereleth) for [the idea](https://twitter.com/gereleth/status/1620164274491654145) and
+[Donny Bertucci](https://github.com/xnought) for the [initial implementation](https://github.com/xnought/svelte-store-anywidget),
+which lead to this package.
+
 ## License
 
 MIT

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,0 +1,41 @@
+# @anywidget/svelte
+
+> Svelte utilities for [**anywidget**](https://anywidget.dev)
+
+## Installation
+
+> **Warning**
+> This API is currently experimental an subject to change.
+
+```sh
+npm install @anywidget/svelte
+```
+
+## Usage
+
+```javascript
+// index.js
+import { createRender } from "@anywidget/svelte";
+import Counter from "./Counter.svelte";
+
+export let render = createRender(Counter);
+```
+
+```svelte
+<!-- Counter.svelte -->
+<script>
+    import { stores } from "@anywidget/svelte";
+    // Access traitlet values as Svelte stores
+    let { count } = stores;
+</script>
+
+<button on:click={() => $count += 1}Count is {$count}</button>
+```
+
+```sh
+rollup -p @rollup/plugin-node-resolve -p rollup-plugin-svelte index.js > bundle.js
+```
+
+## License
+
+MIT

--- a/packages/svelte/index.js
+++ b/packages/svelte/index.js
@@ -24,13 +24,13 @@ let cache = {};
  * @returns {Stores<Model>}
  */
 export function getModelStores() {
-	return new Proxy(/** @type {Stores<Model>} */ ({}), { 
+	return new Proxy(/** @type {Stores<Model>} */ ({}), {
 		get(_, key) {
 			// @ts-expect-error
 			if (cache[key]) return cache[key];
 			// @ts-expect-error
-			return cache[key] = anywriteable(key);
-		}
+			return (cache[key] = anywriteable(key));
+		},
 	});
 }
 

--- a/packages/svelte/index.js
+++ b/packages/svelte/index.js
@@ -19,20 +19,14 @@ export function getModel() {
 /** @type {Record<string, import("svelte/store").Writable<any>>} key */
 let cache = {};
 
-/**
- * @template Model
- * @returns {Stores<Model>}
- */
-export function getModelStores() {
-	return new Proxy(/** @type {Stores<Model>} */ ({}), {
-		get(_, key) {
-			// @ts-expect-error
-			if (cache[key]) return cache[key];
-			// @ts-expect-error
-			return (cache[key] = anywriteable(key));
-		},
-	});
-}
+export const stores = new Proxy(/** @type {Stores<any>} */ ({}), {
+	get(_, key) {
+		// @ts-expect-error
+		if (cache[key]) return cache[key];
+		// @ts-expect-error
+		return (cache[key] = anywriteable(key));
+	},
+});
 
 /**
  * @template T

--- a/packages/svelte/index.js
+++ b/packages/svelte/index.js
@@ -1,0 +1,58 @@
+// @ts-check
+import { onDestroy } from "svelte";
+import { writable } from "svelte/store";
+
+/** @type {import("@anywidget/types").AnyModel} */
+let model;
+
+/** @returns {import("@anywidget/types").AnyModel}*/
+export function getModel() {
+	if (!model) throw new Error("No model");
+	return model;
+}
+
+/** @type {Record<string, import("svelte/store").Writable<any>>} key */
+let cache = {};
+export let stores = new Proxy(/** @type {any} */ ({}), {
+	get(_, key) {
+		if (typeof key !== "string") return;
+		if (!cache[key]) cache[key] = anywriteable(key);
+		return cache[key];
+	},
+});
+
+/**
+ * @template T
+ *
+ * @param {string} key
+ * @returns {import("svelte/store").Writable<T>}
+ */
+export function anywriteable(key) {
+	let { subscribe, set } = writable(model.get(key));
+	let update = () => set(model.get(key));
+	model.on(`change:${key}`, update);
+	onDestroy(() => model.off(`change:${key}`, update));
+	return {
+		subscribe,
+		set(value) {
+			model.set(key, value);
+			model.save_changes();
+		},
+		update(updater) {
+			model.set(key, updater(model.get(key)));
+			model.save_changes();
+		},
+	};
+}
+
+/**
+ * @param {import("svelte").ComponentType} Widget
+ * @returns {import("@anywidget/types").Render}
+ */
+export function createRender(Widget) {
+	return (ctx) => {
+		model = ctx.model;
+		const widget = new Widget({ target: ctx.el });
+		return () => widget.$destroy();
+	};
+}

--- a/packages/svelte/index.js
+++ b/packages/svelte/index.js
@@ -2,19 +2,17 @@
 import { onDestroy } from "svelte";
 import { writable } from "svelte/store";
 
-/** @type {import("@anywidget/types").AnyModel} */
-let model;
-
-/** @returns {import("@anywidget/types").AnyModel}*/
-export function getModel() {
-	if (!model) throw new Error("No model");
-	return model;
-}
-
 /**
  * @template Model
  * @typedef {{ [Key in keyof Model]: import("svelte/store").Writable<Model[Key]> }} Stores
  */
+
+/** @type {import("@anywidget/types").AnyModel} */
+export let model = new Proxy(/** @type {any} */ ({}), {
+	get() {
+		throw new Error("No model. Must first `createRender` to initialize.");
+	},
+});
 
 /** @type {Record<string, import("svelte/store").Writable<any>>} key */
 let cache = {};
@@ -35,7 +33,6 @@ export const stores = new Proxy(/** @type {Stores<any>} */ ({}), {
  * @returns {import("svelte/store").Writable<T>}
  */
 function anywriteable(key) {
-	let model = getModel();
 	let { subscribe, set } = writable(model.get(key));
 	let update = () => set(model.get(key));
 	model.on(`change:${key}`, update);

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@anywidget/svelte",
+	"type": "module",
+	"version": "0.0.0",
+	"description": "Svelte utilities for anywidget",
+	"main": "index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc --declaration --emitDeclarationOnly --declarationMap --outDir dist",
+		"typecheck": "tsc --noEmit"
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
+	},
+	"dependencies": {
+		"@anywidget/types": "workspace:^"
+	},
+	"devDependencies": {
+		"@rollup/plugin-node-resolve": "^15.1.0",
+		"rollup": "^3.26.3",
+		"rollup-plugin-svelte": "^7.1.6",
+		"svelte": "^4.1.1"
+	}
+}

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -12,7 +12,7 @@
 		}
 	},
 	"scripts": {
-		"build": "tsc --declaration --emitDeclarationOnly --declarationMap --outDir dist",
+		"build": "tsc --declaration --emitDeclarationOnly --outDir dist",
 		"typecheck": "tsc --noEmit"
 	},
 	"peerDependencies": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -22,9 +22,6 @@
 		"@anywidget/types": "workspace:^"
 	},
 	"devDependencies": {
-		"@rollup/plugin-node-resolve": "^15.1.0",
-		"rollup": "^3.26.3",
-		"rollup-plugin-svelte": "^7.1.6",
 		"svelte": "^4.1.1"
 	}
 }

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"moduleResolution": "nodenext",
+		"declaration": true,
+		"outDir": "./dist"
+	}
+}

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,8 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"moduleResolution": "nodenext",
-		"declaration": true,
-		"outDir": "./dist"
-	}
+	"extends": "../../tsconfig.json"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -137,6 +137,25 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+
+  packages/svelte:
+    dependencies:
+      '@anywidget/types':
+        specifier: workspace:^
+        version: link:../types
+    devDependencies:
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.1.0
+        version: 15.1.0(rollup@3.26.3)
+      rollup:
+        specifier: ^3.26.3
+        version: 3.26.3
+      rollup-plugin-svelte:
+        specifier: ^7.1.6
+        version: 7.1.6(rollup@3.26.3)(svelte@4.1.1)
+      svelte:
+        specifier: ^4.1.1
+        version: 4.1.1
 
   packages/types: {}
 
@@ -1916,6 +1935,47 @@ packages:
       react-is: 18.2.0
     dev: true
 
+  /@rollup/plugin-node-resolve@15.1.0(rollup@3.26.3):
+    resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-builtin-module: 3.2.1
+      is-module: 1.0.0
+      resolve: 1.22.2
+      rollup: 3.26.3
+    dev: true
+
+  /@rollup/pluginutils@4.2.1:
+    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    dev: true
+
+  /@rollup/pluginutils@5.0.2(rollup@3.26.3):
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.26.3
+    dev: true
+
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
@@ -2489,6 +2549,12 @@ packages:
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  /aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+    dependencies:
+      dequal: 2.0.3
+    dev: true
+
   /array-buffer-byte-length@1.0.0:
     resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
     dependencies:
@@ -2642,6 +2708,12 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /axobject-query@3.2.1:
+    resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
+    dependencies:
+      dequal: 2.0.3
+    dev: true
+
   /babel-plugin-module-resolver@5.0.0:
     resolution: {integrity: sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==}
     engines: {node: '>= 16'}
@@ -2762,6 +2834,11 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  /builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+    dev: true
 
   /bundle-name@3.0.0:
     resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
@@ -2972,6 +3049,16 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  /code-red@1.0.3:
+    resolution: {integrity: sha512-kVwJELqiILQyG5aeuyKFbdsI1fmQy1Cmf7dQ8eGmVuJoaRVdwey7WaMknr2ZFeVSYSKT0rExsa8EGw0aoI/1QQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@types/estree': 1.0.1
+      acorn: 8.10.0
+      estree-walker: 3.0.3
+      periscopic: 3.1.0
+    dev: true
+
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
@@ -3087,6 +3174,14 @@ packages:
       schema-utils: 3.3.0
       semver: 7.5.4
       webpack: 5.88.2(esbuild@0.18.16)(webpack-cli@4.10.0)
+    dev: true
+
+  /css-tree@2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+    dependencies:
+      mdn-data: 2.0.30
+      source-map-js: 1.0.2
     dev: true
 
   /css.escape@1.5.1:
@@ -3558,6 +3653,10 @@ packages:
       '@types/unist': 2.0.7
     dev: false
 
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
   /estree-walker@3.0.0:
     resolution: {integrity: sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ==}
 
@@ -3565,7 +3664,6 @@ packages:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
       '@types/estree': 1.0.1
-    dev: false
 
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -4262,6 +4360,13 @@ packages:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
     engines: {node: '>=4'}
 
+  /is-builtin-module@3.2.1:
+    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
+    engines: {node: '>=6'}
+    dependencies:
+      builtin-modules: 3.3.0
+    dev: true
+
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -4333,6 +4438,10 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
+  /is-module@1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+    dev: true
+
   /is-negative-zero@2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
@@ -4374,7 +4483,6 @@ packages:
     resolution: {integrity: sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==}
     dependencies:
       '@types/estree': 1.0.1
-    dev: false
 
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -4649,6 +4757,10 @@ packages:
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
     engines: {node: '>=14'}
+    dev: true
+
+  /locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
     dev: true
 
   /locate-path@3.0.0:
@@ -4940,6 +5052,10 @@ packages:
     resolution: {integrity: sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==}
     dependencies:
       '@types/mdast': 3.0.12
+
+  /mdn-data@2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+    dev: true
 
   /meow@6.1.1:
     resolution: {integrity: sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==}
@@ -5720,7 +5836,6 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 3.0.3
       is-reference: 3.0.1
-    dev: false
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -6212,6 +6327,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /resolve.exports@2.0.2:
+    resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
+    engines: {node: '>=10'}
+    dev: true
+
   /resolve@1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
@@ -6267,6 +6387,19 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.1.7
+    dev: true
+
+  /rollup-plugin-svelte@7.1.6(rollup@3.26.3)(svelte@4.1.1):
+    resolution: {integrity: sha512-nVFRBpGWI2qUY1OcSiEEA/kjCY2+vAjO9BI8SzA7NRrh2GTunLd6w2EYmnMt/atgdg8GvcNjLsmZmbQs/u4SQA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      rollup: '>=2.0.0'
+      svelte: '>=3.5.0'
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      resolve.exports: 2.0.2
+      rollup: 3.26.3
+      svelte: 4.1.1
     dev: true
 
   /rollup@3.26.3:
@@ -6744,6 +6877,25 @@ packages:
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  /svelte@4.1.1:
+    resolution: {integrity: sha512-Enick5fPFISLoVy0MFK45cG+YlQt6upw8skEK9zzTpJnH1DqEv8xOZwizCGSo3Q6HZ7KrZTM0J18poF7aQg5zw==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.18
+      acorn: 8.10.0
+      aria-query: 5.3.0
+      axobject-query: 3.2.1
+      code-red: 1.0.3
+      css-tree: 2.3.1
+      estree-walker: 3.0.3
+      is-reference: 3.0.1
+      locate-character: 3.0.0
+      magic-string: 0.30.1
+      periscopic: 3.1.0
+    dev: true
 
   /svg-url-loader@6.0.0(webpack@5.88.2):
     resolution: {integrity: sha512-Qr5SCKxyxKcRnvnVrO3iQj9EX/v40UiGEMshgegzV7vpo3yc+HexELOdtWcA3MKjL8IyZZ1zOdcILmDEa/8JJQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,15 +144,6 @@ importers:
         specifier: workspace:^
         version: link:../types
     devDependencies:
-      '@rollup/plugin-node-resolve':
-        specifier: ^15.1.0
-        version: 15.1.0(rollup@3.26.3)
-      rollup:
-        specifier: ^3.26.3
-        version: 3.26.3
-      rollup-plugin-svelte:
-        specifier: ^7.1.6
-        version: 7.1.6(rollup@3.26.3)(svelte@4.1.1)
       svelte:
         specifier: ^4.1.1
         version: 4.1.1
@@ -1935,47 +1926,6 @@ packages:
       react-is: 18.2.0
     dev: true
 
-  /@rollup/plugin-node-resolve@15.1.0(rollup@3.26.3):
-    resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.78.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.3)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-builtin-module: 3.2.1
-      is-module: 1.0.0
-      resolve: 1.22.2
-      rollup: 3.26.3
-    dev: true
-
-  /@rollup/pluginutils@4.2.1:
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    dev: true
-
-  /@rollup/pluginutils@5.0.2(rollup@3.26.3):
-    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@types/estree': 1.0.1
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-      rollup: 3.26.3
-    dev: true
-
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
@@ -2835,11 +2785,6 @@ packages:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  /builtin-modules@3.3.0:
-    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
-    engines: {node: '>=6'}
-    dev: true
-
   /bundle-name@3.0.0:
     resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
     engines: {node: '>=12'}
@@ -3653,10 +3598,6 @@ packages:
       '@types/unist': 2.0.7
     dev: false
 
-  /estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
-
   /estree-walker@3.0.0:
     resolution: {integrity: sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ==}
 
@@ -4360,13 +4301,6 @@ packages:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
     engines: {node: '>=4'}
 
-  /is-builtin-module@3.2.1:
-    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
-    engines: {node: '>=6'}
-    dependencies:
-      builtin-modules: 3.3.0
-    dev: true
-
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -4437,10 +4371,6 @@ packages:
   /is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
-
-  /is-module@1.0.0:
-    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
-    dev: true
 
   /is-negative-zero@2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
@@ -6327,11 +6257,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /resolve.exports@2.0.2:
-    resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
-    engines: {node: '>=10'}
-    dev: true
-
   /resolve@1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
@@ -6387,19 +6312,6 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.1.7
-    dev: true
-
-  /rollup-plugin-svelte@7.1.6(rollup@3.26.3)(svelte@4.1.1):
-    resolution: {integrity: sha512-nVFRBpGWI2qUY1OcSiEEA/kjCY2+vAjO9BI8SzA7NRrh2GTunLd6w2EYmnMt/atgdg8GvcNjLsmZmbQs/u4SQA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      rollup: '>=2.0.0'
-      svelte: '>=3.5.0'
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      resolve.exports: 2.0.2
-      rollup: 3.26.3
-      svelte: 4.1.1
     dev: true
 
   /rollup@3.26.3:


### PR DESCRIPTION
Towards #202 

Proof of concept, inspired by https://github.com/xnought/svelte-store-anywidget.

Not sure my `onDestroy` behavior will clean things up correctly. Maybe we could keep WeakMap/WeakSet to keep track of stores without requiring users to explicitly cleanup. Thinking the Proxy stuff might be a little too much magic, but I like the restructuring API (you get autocomplete with typescript).

Usage:

```svelte
<script>
    import { stores } from "@anywidget/svelte";
    const { count } = stores;
</script>

<button on:click={() => $count += 1}Count is {$count}</button>
```

```js
import { createRender } from "@anywidget/svelte";
import Counter from "./Counter.svelte";

export const render = createRender(Counter);
```

The `Stores` also is generic over a Model object for those using TypeScript. I took this casting pattern from astro.

```svelte
<script lang="ts">
    import { stores, type Stores } from "@anywidget/svelte";
    const { count } = stores as Stores<{ count: number }>;
</script>

<button on:click={() => $count++}Count is {$count}</button>
```

Curious what you think @xnought @gereleth. Definitely a prototype and would love to find a solution that is most sveltey.

Update: rather than react-like hooks the `stores` and `model` are exposed as constants to the child module.
