### PR TITLE
Making create-anywidget bulletprooved

### DIFF
--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -20,7 +20,6 @@ export async function create(target, options) {
   const updatedContentFiles = replaceWidgetName(updatedFiles, options);
 
   const updatedPathFiles = updateFilePaths(updatedContentFiles, copyFrom, copyTo);
-  console.log(copyTo);
   try {
     await createFiles(updatedPathFiles);
     console.log("All files created successfully!");

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -63,7 +63,12 @@ function replaceWidgetName(files, newName) {
 function updateFilePaths(files, sourceDir, destDir, newName) {
   return files.map((file) => {
     let newPath = file.path.replace(sourceDir, destDir);
-    newPath = newPath.replace(/my_widget/g, newName); // Replace folder name
+    
+    // Check if path has the structure 'src/my_widget'
+    if (newPath.includes('src/my_widget')) {
+      newPath = newPath.replace(/src\/my_widget/g, 'src/' + newName);
+    }
+
     file.path = newPath;
     return file;
   });

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -7,20 +7,20 @@ export async function create(target, options) {
   const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
   const copyFrom = path.resolve(__dirname, options.template);
   const copyTo = target;
-  const newName = snakecase(options.name); 
+  const newName = snakecase(options.name);
 
   const allFiles = await gatherFiles(copyFrom);
   const updatedFiles = renameGitignore(allFiles);
-  const updatedContentFiles = replaceWidgetName(updatedFiles, newName); // Pass newName as argument
-  const updatedPathFiles = updateFilePaths(updatedContentFiles, copyFrom, copyTo, newName); // Pass newName as argument
+  const updatedContentFiles = replaceWidgetName(updatedFiles, newName);
+  const updatedPathFiles = updateFilePaths(
+    updatedContentFiles,
+    copyFrom,
+    copyTo,
+    newName
+  );
 
-  console.log(copyTo);
-  try {
-    await createFiles(updatedPathFiles);
-    console.log("All files created successfully!");
-  } catch (err) {
-    console.error("Error writing files:", err);
-  }
+  await writeFiles(updatedPathFiles);
+  return updatedPathFiles.map((file) => file.path);
 }
 
 async function gatherFiles(startDir) {
@@ -63,10 +63,10 @@ function replaceWidgetName(files, newName) {
 function updateFilePaths(files, sourceDir, destDir, newName) {
   return files.map((file) => {
     let newPath = file.path.replace(sourceDir, destDir);
-    
+
     // Check if path has the structure 'src/my_widget'
-    if (newPath.includes('src/my_widget')) {
-      newPath = newPath.replace(/src\/my_widget/g, 'src/' + newName);
+    if (newPath.includes("src/my_widget")) {
+      newPath = newPath.replace(/src\/my_widget/g, "src/" + newName);
     }
 
     file.path = newPath;
@@ -79,7 +79,6 @@ async function createFiles(files) {
     await fs.mkdir(path.dirname(file.path), { recursive: true });
     // Write (or overwrite) the file
     await fs.writeFile(file.path, file.content, "utf-8");
-    console.log(`Created: ${file.path}`);
   });
 
   await Promise.all(writePromises);

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -1,70 +1,96 @@
 // @ts-check
+
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as url from "node:url";
-
 import snakecase from "just-snake-case";
 
-let __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-
-/** @param {string} root */
-async function* walk(root) {
-	for (let entry of await fs.readdir(root, { withFileTypes: true })) {
-		if (entry.isFile()) {
-			yield {
-				type: "file",
-				path: path.resolve(root, entry.name),
-			};
-		} else if (entry.isDirectory()) {
-			yield {
-				type: "directory",
-				path: path.resolve(root, entry.name),
-			};
-			yield* walk(path.resolve(root, entry.name));
-		} else {
-			throw Error("unknown type");
-		}
-	}
-}
-
-/**
- * @param {string} root
- * @param {string} old_name
- * @param {string} new_name
- */
-async function walk_and_rename(root, old_name, new_name) {
-	let entries = await fs.readdir(root, { withFileTypes: true });
-	for (let entry of entries) {
-		let current_path = path.join(root, entry.name);
-		if (entry.isDirectory()) {
-			if (entry.name === old_name) {
-				let new_path = path.join(root, new_name);
-				await fs.rename(current_path, new_path);
-				current_path = new_path;
-			}
-			await walk_and_rename(current_path, old_name, new_name);
-		} else if (entry.isFile()) {
-			if (entry.name === "_gitignore") {
-				let new_path = current_path.replace("_gitignore", ".gitignore");
-				await fs.rename(current_path, new_path);
-				current_path = new_path;
-			}
-			let content = await fs.readFile(current_path, "utf-8");
-			content = content.replace(new RegExp(old_name, "g"), new_name);
-			await fs.writeFile(current_path, content, "utf8");
-		} else {
-			throw Error("unknown type");
-		}
-	}
-}
-
-/**
- * @param {string} target
- * @param {Record<string, any>} options
- */
 export async function create(target, options) {
-	await fs.cp(path.resolve(__dirname, options.template), target, {
-		recursive: true,
-	});
-	await walk_and_rename(target, "my_widget", snakecase(options.name));
+  const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+  const copyFrom = path.resolve(__dirname, options.template);
+  const copyTo = target;
+
+  // read all files from the template folder and store them in a json file
+  const allFiles = await gatherFiles(copyFrom);
+
+  // rename the path that is named _gitignore to .gitignore
+  const updatedFiles = renameGitignore(allFiles);
+
+  const updatedContentFiles = replaceWidgetName(updatedFiles, options);
+
+  const updatedPathFiles = updateFilePaths(updatedContentFiles, copyFrom, copyTo);
+  console.log(copyTo);
+  try {
+    await createFiles(updatedPathFiles);
+    console.log("All files created successfully!");
+  } catch (err) {
+    console.error("Error writing files:", err);
+  }
+}
+
+async function gatherFiles(startDir) {
+  const results = [];
+
+  async function walk(dir) {
+    const files = await fs.readdir(dir);
+
+    for (const file of files) {
+      const entry = path.join(dir, file);
+      const stats = await fs.stat(entry);
+
+      if (stats.isDirectory()) {
+        await walk(entry);
+      } else {
+        const content = await fs.readFile(entry, "utf-8");
+        results.push({ content, path: entry });
+      }
+    }
+  }
+
+  await walk(startDir);
+  return results;
+}
+
+function renameGitignore(files) {
+  return files.map((file) => {
+    if (path.basename(file.path) === "_gitignore") {
+      file.path = path.join(path.dirname(file.path), ".gitignore");
+    }
+    return file;
+  });
+}
+
+function replaceWidgetName(files, options) {
+  const newName = snakecase(options.name);
+  return files.map((file) => {
+    file.content = file.content.replace(/my_widget/g, newName);
+    return file;
+  });
+}
+function updateFilePaths(files, sourceDir, destDir) {
+  return files.map((file) => {
+    file.path = file.path.replace(sourceDir, destDir);
+    return file;
+  });
+}
+
+/**
+ * Writes the files to the specified paths with the given content.
+ * @param {Array} files - The array of file objects to write.
+ * @returns {Promise} Resolves when all files are written.
+ */
+async function createFiles(files) {
+  const writePromises = files.map(async (file) => {
+    // Ensure the directory structure exists
+    await fs.mkdir(path.dirname(file.path), { recursive: true });
+
+    // Write (or overwrite) the file
+    await fs.writeFile(file.path, file.content, "utf-8");
+
+    // Log the file that was written
+    console.log(`Created: ${file.path}`);
+  });
+
+  return Promise.all(writePromises);
 }

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -82,5 +82,5 @@ async function createFiles(files) {
     console.log(`Created: ${file.path}`);
   });
 
-  return Promise.all(writePromises);
+  await Promise.all(writePromises);
 }

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -19,7 +19,7 @@ export async function create(target, options) {
     newName
   );
 
-  await writeFiles(updatedPathFiles);
+  await createFiles(updatedPathFiles);
   return updatedPathFiles.map((file) => file.path);
 }
 

--- a/packages/create-anywidget/index.js
+++ b/packages/create-anywidget/index.js
@@ -70,7 +70,7 @@ const options = await p.group(
 );
 
 await create(cwd, {
-  name: path.resolve(cwd),
+	name: path.basename(path.resolve(cwd)),
   template: /** @type {'react'} */ (options.template),
 });
 

--- a/packages/create-anywidget/index.js
+++ b/packages/create-anywidget/index.js
@@ -89,7 +89,7 @@ console.log(`  ${i++}: ${bold(cyan("npm install"))} (or pnpm install, etc)`);
 // prettier-ignore
 console.log(
 	`  ${i++}: ${
-		bold(cyan('git add -A && git commit -m "add widget infrastructure"'))
+		bold(cyan('git init && git add -A && git commit -m "Initial commit"'))
 	} (optional)`,
 );
 

--- a/packages/create-anywidget/index.js
+++ b/packages/create-anywidget/index.js
@@ -10,8 +10,8 @@ import { bold, cyan, grey } from "kleur/colors";
 import { create } from "./create.js";
 
 let pkg = await fs.promises
-	.readFile(new URL("package.json", import.meta.url), "utf-8")
-	.then(JSON.parse);
+  .readFile(new URL("package.json", import.meta.url), "utf-8")
+  .then(JSON.parse);
 
 let cwd = process.argv[2] || ".";
 
@@ -22,56 +22,56 @@ ${grey(`create-anywidget version ${pkg.version}`)}
 p.intro("Welcome to anywidget!");
 
 if (cwd === ".") {
-	const dir = await p.text({
-		message: "Where should we create your project?",
-		placeholder: "  (hit Enter to use current directory)",
-	});
-	if (p.isCancel(dir)) process.exit(1);
-	if (dir) {
-		cwd = /** @type {string} */ (dir);
-	}
+  const dir = await p.text({
+    message: "Where should we create your project?",
+    placeholder: "  (hit Enter to use current directory)",
+  });
+  if (p.isCancel(dir)) process.exit(1);
+  if (dir) {
+    cwd = /** @type {string} */ (dir);
+  }
 }
 
 if (fs.existsSync(cwd)) {
-	if (fs.readdirSync(cwd).length > 0) {
-		let force = await p.confirm({
-			message: "Directory not empty. Continue?",
-			initialValue: false,
-		});
-		// bail if `force` is `false` or the user cancelled with Ctrl-C
-		if (force !== true) {
-			process.exit(1);
-		}
-	}
+  if (fs.readdirSync(cwd).length > 0) {
+    let force = await p.confirm({
+      message:
+        "Directory not empty. Continue? No files will be overwritten, and the git archive won't be touched.",
+      initialValue: false,
+    });
+    // bail if `force` is `false` or the user cancelled with Ctrl-C
+    if (force !== true) {
+      process.exit(1);
+    }
+  }
 }
 
 let __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-
 const options = await p.group(
-	{
-		template: () =>
-			p.select({
-				message: "Which anywidget template?",
-				// @ts-expect-error i have no idea what is going on here
-				options: fs
-					.readdirSync(__dirname)
-					.filter((dir) => dir.startsWith("template-"))
-					.map((dir) => {
-						let title = dir.replace(/^template-/, "");
-						return {
-							label: title,
-							hint: `A ${title} anywidget template`,
-							value: dir,
-						};
-					}),
-			}),
-	},
-	{ onCancel: () => process.exit(1) },
+  {
+    template: () =>
+      p.select({
+        message: "Which anywidget template?",
+        // @ts-expect-error i have no idea what is going on here
+        options: fs
+          .readdirSync(__dirname)
+          .filter((dir) => dir.startsWith("template-"))
+          .map((dir) => {
+            let title = dir.replace(/^template-/, "");
+            return {
+              label: title,
+              hint: `A ${title} anywidget template`,
+              value: dir,
+            };
+          }),
+      }),
+  },
+  { onCancel: () => process.exit(1) }
 );
 
 await create(cwd, {
-	name: path.basename(path.resolve(cwd)),
-	template: /** @type {'react'} */ (options.template),
+  name: path.resolve(cwd),
+  template: /** @type {'react'} */ (options.template),
 });
 
 p.outro("Your project is ready!");
@@ -81,7 +81,7 @@ let i = 1;
 
 const relative = path.relative(process.cwd(), cwd);
 if (relative !== "") {
-	console.log(`  ${i++}: ${bold(cyan(`cd ${relative}`))}`);
+  console.log(`  ${i++}: ${bold(cyan(`cd ${relative}`))}`);
 }
 
 console.log(`  ${i++}: ${bold(cyan("npm install"))} (or pnpm install, etc)`);
@@ -89,12 +89,12 @@ console.log(`  ${i++}: ${bold(cyan("npm install"))} (or pnpm install, etc)`);
 // prettier-ignore
 console.log(
 	`  ${i++}: ${
-		bold(cyan('git init && git add -A && git commit -m "Initial commit"'))
+		bold(cyan('git add -A && git commit -m "add widget infrastructure"'))
 	} (optional)`,
 );
 
 console.log(`  ${i++}: ${bold(cyan("npm run dev"))}`);
 console.log(`\nTo close the dev server, hit ${bold(cyan("Ctrl-C"))}`);
 console.log(
-	`\nStuck? Visit us at ${cyan("https://github.com/manzt/anywidget")}`,
+  `\nStuck? Visit us at ${cyan("https://github.com/manzt/anywidget")}`
 );

--- a/packages/create-anywidget/index.js
+++ b/packages/create-anywidget/index.js
@@ -35,8 +35,7 @@ if (cwd === ".") {
 if (fs.existsSync(cwd)) {
   if (fs.readdirSync(cwd).length > 0) {
     let force = await p.confirm({
-      message:
-        "Directory not empty. Continue? No files will be overwritten, and the git archive won't be touched.",
+      message: "Directory not empty. Continue?",
       initialValue: false,
     });
     // bail if `force` is `false` or the user cancelled with Ctrl-C
@@ -69,10 +68,16 @@ const options = await p.group(
   { onCancel: () => process.exit(1) }
 );
 
-await create(cwd, {
-	name: path.basename(path.resolve(cwd)),
-  template: /** @type {'react'} */ (options.template),
-});
+try {
+  const writtenPaths = await create(cwd, {
+    name: path.basename(path.resolve(cwd)),
+    template: /** @type {'react'} */ (options.template),
+  });
+  console.log("All files created successfully:", writtenPaths);
+} catch (err) {
+  console.error("Error writing files:", err);
+  process.exit(1);
+}
 
 p.outro("Your project is ready!");
 


### PR DESCRIPTION
Follow up from https://github.com/Octoframes/anywidget-minimal-react-template/issues/3

In the old version of create-anywidget, copying template files  and then renaming them in the target dir was breaking the git repo.

With this new approach "Read, save to json, modify json, write to the file system", this error does not occur any more
Tested this via:

mkdir hi && cd hi && git init && touch hello.py && echo 'print("hello")' > hello.py
git add . && git commit -m "first file"
node /Users/jan-hendrik/projects/anywidget/packages/create-anywidget/index.js hi
and that works now!