### PR TITLE
feat(create-anywidget): use `static` folder for JS build assets

### DIFF
--- a/.changeset/hot-dingos-taste.md
+++ b/.changeset/hot-dingos-taste.md
@@ -1,0 +1,5 @@
+---
+"create-anywidget": patch
+---
+
+feat: use `src/my_widget/static` directory for build assets

--- a/packages/create-anywidget/template-react-ts/package.json
+++ b/packages/create-anywidget/template-react-ts/package.json
@@ -1,7 +1,7 @@
 {
 	"scripts": {
 		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "esbuild --minify --format=esm --bundle --outdir=src/my_widget js/src/widget.tsx"
+		"build": "esbuild --minify --format=esm --bundle --outdir=src/my_widget/static js/src/widget.tsx"
 	},
 	"dependencies": {
 		"@anywidget/react": "^0.0.2",

--- a/packages/create-anywidget/template-react-ts/src/my_widget/__init__.py
+++ b/packages/create-anywidget/template-react-ts/src/my_widget/__init__.py
@@ -11,6 +11,6 @@ except importlib.metadata.PackageNotFoundError:
 
 
 class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "widget.js"
-    _css = pathlib.Path(__file__).parent / "widget.css"
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
     value = traitlets.Int(0).tag(sync=True)

--- a/packages/create-anywidget/template-react/package.json
+++ b/packages/create-anywidget/template-react/package.json
@@ -1,7 +1,7 @@
 {
 	"scripts": {
 		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "esbuild --minify --format=esm --bundle --outdir=src/my_widget js/widget.jsx"
+		"build": "esbuild --minify --format=esm --bundle --outdir=src/my_widget/static js/widget.jsx"
 	},
 	"dependencies": {
 		"@anywidget/react": "^0.0.2",

--- a/packages/create-anywidget/template-react/src/my_widget/__init__.py
+++ b/packages/create-anywidget/template-react/src/my_widget/__init__.py
@@ -11,6 +11,6 @@ except importlib.metadata.PackageNotFoundError:
 
 
 class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "widget.js"
-    _css = pathlib.Path(__file__).parent / "widget.css"
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
     value = traitlets.Int(0).tag(sync=True)

--- a/packages/create-anywidget/template-vanilla-ts/package.json
+++ b/packages/create-anywidget/template-vanilla-ts/package.json
@@ -1,7 +1,7 @@
 {
 	"scripts": {
 		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "esbuild --minify --format=esm --bundle --outdir=src/my_widget js/src/widget.ts",
+		"build": "esbuild --minify --format=esm --bundle --outdir=src/my_widget/static js/src/widget.ts",
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {

--- a/packages/create-anywidget/template-vanilla-ts/src/my_widget/__init__.py
+++ b/packages/create-anywidget/template-vanilla-ts/src/my_widget/__init__.py
@@ -11,6 +11,6 @@ except importlib.metadata.PackageNotFoundError:
 
 
 class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "widget.js"
-    _css = pathlib.Path(__file__).parent / "widget.css"
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
     value = traitlets.Int(0).tag(sync=True)

--- a/packages/create-anywidget/template-vanilla/package.json
+++ b/packages/create-anywidget/template-vanilla/package.json
@@ -1,7 +1,7 @@
 {
 	"scripts": {
 		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "esbuild --minify --format=esm --bundle --outdir=src/my_widget js/widget.js"
+		"build": "esbuild --minify --format=esm --bundle --outdir=src/my_widget/static js/widget.js"
 	},
 	"devDependencies": {
 		"esbuild": "^0.19.2"

--- a/packages/create-anywidget/template-vanilla/src/my_widget/__init__.py
+++ b/packages/create-anywidget/template-vanilla/src/my_widget/__init__.py
@@ -11,6 +11,6 @@ except importlib.metadata.PackageNotFoundError:
 
 
 class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "widget.js"
-    _css = pathlib.Path(__file__).parent / "widget.css"
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
     value = traitlets.Int(0).tag(sync=True)


### PR DESCRIPTION
Fixes #228
