### PR TITLE
feat(create-anywidget): Support Bun

### DIFF
--- a/.changeset/small-spies-sort.md
+++ b/.changeset/small-spies-sort.md
@@ -1,0 +1,11 @@
+---
+"create-anywidget": minor
+---
+
+feat: Support Bun and prefer built-in bundler over `esbuild`
+
+When running `bun create anywidget@latest`, the resulting package.json scripts prefer the built-in bundler over esbuild. As a result, the vanilla JS template has no dependencies.
+
+```sh
+bun create anywidget@latest
+```

--- a/.changeset/small-spies-sort.md
+++ b/.changeset/small-spies-sort.md
@@ -4,7 +4,9 @@
 
 feat: Support Bun and prefer built-in bundler over `esbuild`
 
-When running `bun create anywidget@latest`, the resulting package.json scripts prefer the built-in bundler over esbuild. As a result, the vanilla JS template has no dependencies.
+When running `bun create anywidget@latest`, the resulting package.json scripts
+prefer the built-in bundler over esbuild. As a result, the vanilla JS template
+has no dependencies.
 
 ```sh
 bun create anywidget@latest

--- a/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
@@ -13,6 +13,7 @@ pip install ipyfoo
   },
   {
     "content": "node_modules
+.venv
 dist
 
 # Python
@@ -57,6 +58,7 @@ features = [\\"dev\\"]
 
 
 [tool.hatch.build]
+only-packages = true
 artifacts = [\\"src/ipyfoo/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
@@ -154,6 +156,7 @@ pip install ipyfoo
   },
   {
     "content": "node_modules
+.venv
 dist
 
 # Python
@@ -203,6 +206,7 @@ features = [\\"dev\\"]
 
 
 [tool.hatch.build]
+only-packages = true
 artifacts = [\\"src/ipyfoo/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
@@ -328,6 +332,7 @@ pip install ipyfoo
   },
   {
     "content": "node_modules
+.venv
 dist
 
 # Python
@@ -368,6 +373,7 @@ features = [\\"dev\\"]
 
 
 [tool.hatch.build]
+only-packages = true
 artifacts = [\\"src/ipyfoo/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
@@ -509,6 +515,7 @@ features = [\\"dev\\"]
   },
   {
     "content": "node_modules
+.venv
 dist
 
 # Python
@@ -540,7 +547,7 @@ class Counter(anywidget.AnyWidget):
     "path": "src/ipyfoo/__init__.py",
   },
   {
-    "content": "import confetti from \\"https://esm.sh/canvas-confetti@1.6.0\\";
+    "content": "import confetti from \\"https://esm.sh/canvas-confetti@1\\";
 
 /** @typedef {{ value: number }} Model */
 
@@ -605,6 +612,7 @@ pip install ipyfoo
   },
   {
     "content": "node_modules
+.venv
 dist
 
 # Python
@@ -649,6 +657,7 @@ features = [\\"dev\\"]
 
 
 [tool.hatch.build]
+only-packages = true
 artifacts = [\\"src/ipyfoo/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
@@ -1320,7 +1329,7 @@ class Counter(anywidget.AnyWidget):
     "path": "src/ipyfoo/__init__.py",
   },
   {
-    "content": "import confetti from \\"https://esm.sh/canvas-confetti@1.6.0\\";
+    "content": "import confetti from \\"https://esm.sh/canvas-confetti@1\\";
 
 /** @typedef {{ value: number }} Model */
 

--- a/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
@@ -1,5 +1,773 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`create-anywidget (Bun) > template-react 1`] = `
+[
+  {
+    "content": "# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+",
+    "path": "README.md",
+  },
+  {
+    "content": "node_modules
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+",
+    "path": ".gitignore",
+  },
+  {
+    "content": "{
+	\\"scripts\\": {
+		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
+		\\"build\\": \\"bun build js/widget.jsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]\\"
+	},
+	\\"dependencies\\": {
+		\\"@anywidget/react\\": \\"0.0.2\\",
+		\\"react\\": \\"^18.2.0\\",
+		\\"react-dom\\": \\"^18.2.0\\"
+	},
+	\\"devDependencies\\": {}
+}",
+    "path": "package.json",
+  },
+  {
+    "content": "[build-system]
+requires = [\\"hatchling\\"]
+build-backend = \\"hatchling.build\\"
+
+[project]
+name = \\"ipyfoo\\"
+version = \\"0.0.0\\"
+dependencies = [\\"anywidget\\"]
+
+[project.optional-dependencies]
+dev = [\\"watchfiles\\", \\"jupyterlab\\"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = [\\"dev\\"]
+
+
+[tool.hatch.build]
+artifacts = [\\"src/ipyfoo/static/*\\"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = \\"hatch_jupyter_builder.npm_builder\\"
+ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
+skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = \\"npm\\"
+build_cmd = \\"build\\"
+path = \\"js\\"
+",
+    "path": "pyproject.toml",
+  },
+  {
+    "content": "import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = \\"unknown\\"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.js\\"
+    _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
+    value = traitlets.Int(0).tag(sync=True)
+",
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": "import * as React from \\"react\\";
+import { createRender, useModelState } from \\"@anywidget/react\\";
+import \\"./widget.css\\";
+
+export const render = createRender(() => {
+	const [value, setValue] = useModelState(\\"value\\");
+	return (
+		<button
+			className=\\"ipyfoo-counter-button\\"
+			onClick={() => setValue(value + 1)}
+		>
+			count is {value}
+		</button>
+	);
+});
+",
+    "path": "js/widget.jsx",
+  },
+  {
+    "content": ".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: \\"Roboto\\", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+",
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) > template-react-ts 1`] = `
+[
+  {
+    "content": "# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+",
+    "path": "README.md",
+  },
+  {
+    "content": "node_modules
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+",
+    "path": ".gitignore",
+  },
+  {
+    "content": "{
+	\\"scripts\\": {
+		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
+		\\"build\\": \\"bun build js/widget.tsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]\\",
+		\\"typecheck\\": \\"tsc --noEmit\\"
+	},
+	\\"dependencies\\": {
+		\\"@anywidget/react\\": \\"0.0.2\\",
+		\\"react\\": \\"^18.2.0\\",
+		\\"react-dom\\": \\"^18.2.0\\"
+	},
+	\\"devDependencies\\": {
+		\\"@types/react\\": \\"^18.2.21\\",
+		\\"@types/react-dom\\": \\"^18.2.7\\",
+		\\"typescript\\": \\"^5.2.2\\"
+	}
+}",
+    "path": "package.json",
+  },
+  {
+    "content": "[build-system]
+requires = [\\"hatchling\\"]
+build-backend = \\"hatchling.build\\"
+
+[project]
+name = \\"ipyfoo\\"
+version = \\"0.0.0\\"
+dependencies = [\\"anywidget\\"]
+
+[project.optional-dependencies]
+dev = [\\"watchfiles\\", \\"jupyterlab\\"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = [\\"dev\\"]
+
+
+[tool.hatch.build]
+artifacts = [\\"src/ipyfoo/static/*\\"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = \\"hatch_jupyter_builder.npm_builder\\"
+ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
+skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = \\"npm\\"
+build_cmd = \\"build\\"
+path = \\"js\\"
+",
+    "path": "pyproject.toml",
+  },
+  {
+    "content": "import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = \\"unknown\\"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.js\\"
+    _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
+    value = traitlets.Int(0).tag(sync=True)
+",
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": "import * as React from \\"react\\";
+import { createRender, useModelState } from \\"@anywidget/react\\";
+import \\"./widget.css\\";
+
+export const render = createRender(() => {
+	const [value, setValue] = useModelState<number>(\\"value\\");
+	return (
+		<button
+			className=\\"ipyfoo-counter-button\\"
+			onClick={() => setValue(value + 1)}
+		>
+			count is {value}
+		</button>
+	);
+});
+",
+    "path": "js/widget.tsx",
+  },
+  {
+    "content": ".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: \\"Roboto\\", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+",
+    "path": "js/widget.css",
+  },
+  {
+    "content": "{
+	\\"include\\": [
+		\\"js\\"
+	],
+	\\"compilerOptions\\": {
+		\\"target\\": \\"ES2020\\",
+		\\"module\\": \\"ESNext\\",
+		\\"lib\\": [
+			\\"ES2020\\",
+			\\"DOM\\",
+			\\"DOM.Iterable\\"
+		],
+		\\"skipLibCheck\\": true,
+		\\"moduleResolution\\": \\"bundler\\",
+		\\"allowImportingTsExtensions\\": true,
+		\\"resolveJsonModule\\": true,
+		\\"isolatedModules\\": true,
+		\\"noEmit\\": true,
+		\\"jsx\\": \\"react\\",
+		\\"strict\\": true,
+		\\"noUnusedLocals\\": true,
+		\\"noUnusedParameters\\": true,
+		\\"noFallthroughCasesInSwitch\\": true
+	}
+}",
+    "path": "tsconfig.json",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) > template-vanilla 1`] = `
+[
+  {
+    "content": "# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+",
+    "path": "README.md",
+  },
+  {
+    "content": "node_modules
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+",
+    "path": ".gitignore",
+  },
+  {
+    "content": "{
+	\\"scripts\\": {
+		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
+		\\"build\\": \\"bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]\\"
+	},
+	\\"dependencies\\": {},
+	\\"devDependencies\\": {}
+}",
+    "path": "package.json",
+  },
+  {
+    "content": "[build-system]
+requires = [\\"hatchling\\"]
+build-backend = \\"hatchling.build\\"
+
+[project]
+name = \\"ipyfoo\\"
+version = \\"0.0.0\\"
+dependencies = [\\"anywidget\\"]
+
+[project.optional-dependencies]
+dev = [\\"watchfiles\\", \\"jupyterlab\\"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = [\\"dev\\"]
+
+
+[tool.hatch.build]
+artifacts = [\\"src/ipyfoo/static/*\\"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = \\"hatch_jupyter_builder.npm_builder\\"
+ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
+skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = \\"npm\\"
+build_cmd = \\"build\\"
+path = \\"js\\"
+",
+    "path": "pyproject.toml",
+  },
+  {
+    "content": "import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = \\"unknown\\"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.js\\"
+    _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
+    value = traitlets.Int(0).tag(sync=True)
+",
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": "import \\"./widget.css\\";
+
+export function render({ model, el }) {
+	let btn = document.createElement(\\"button\\");
+	btn.classList.add(\\"ipyfoo-counter-button\\");
+	btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
+	btn.addEventListener(\\"click\\", () => {
+		model.set(\\"value\\", model.get(\\"value\\") + 1);
+		model.save_changes();
+	});
+	model.on(\\"change:value\\", () => {
+		btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
+	});
+	el.appendChild(btn);
+}
+",
+    "path": "js/widget.js",
+  },
+  {
+    "content": ".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: \\"Roboto\\", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+",
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) > template-vanilla-deno-jsdoc 1`] = `
+[
+  {
+    "content": "# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+",
+    "path": "README.md",
+  },
+  {
+    "content": "[build-system]
+requires = [\\"hatchling\\"]
+build-backend = \\"hatchling.build\\"
+
+[project]
+name = \\"ipyfoo\\"
+version = \\"0.0.0\\"
+dependencies = [\\"anywidget\\"]
+
+[project.optional-dependencies]
+dev = [\\"watchfiles\\", \\"jupyterlab\\"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = [\\"dev\\"]
+",
+    "path": "pyproject.toml",
+  },
+  {
+    "content": "{
+	\\"lock\\": false,
+	\\"compilerOptions\\": {
+		\\"checkJs\\": true,
+		\\"allowJs\\": true,
+		\\"lib\\": [
+			\\"ES2020\\",
+			\\"DOM\\",
+			\\"DOM.Iterable\\"
+		]
+	},
+	\\"fmt\\": {
+		\\"useTabs\\": true
+	},
+	\\"lint\\": {
+		\\"rules\\": {
+			\\"exclude\\": [
+				\\"prefer-const\\"
+			]
+		}
+	}
+}",
+    "path": "deno.json",
+  },
+  {
+    "content": "node_modules
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+
+",
+    "path": ".gitignore",
+  },
+  {
+    "content": "import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = \\"unknown\\"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.js\\"
+    _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
+    value = traitlets.Int(0).tag(sync=True)
+",
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": "import confetti from \\"https://esm.sh/canvas-confetti@1.6.0\\";
+
+/** @typedef {{ value: number }} Model */
+
+/** @type {import(\\"npm:@anywidget/types\\").Render<Model>} */
+export function render({ model, el }) {
+	let btn = document.createElement(\\"button\\");
+	btn.classList.add(\\"ipyfoo-counter-button\\");
+	btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
+	btn.addEventListener(\\"click\\", () => {
+		model.set(\\"value\\", model.get(\\"value\\") + 1);
+		model.save_changes();
+	});
+	model.on(\\"change:value\\", () => {
+		confetti();
+		btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
+	});
+	el.appendChild(btn);
+}
+",
+    "path": "src/ipyfoo/static/widget.js",
+  },
+  {
+    "content": ".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: \\"Roboto\\", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+",
+    "path": "src/ipyfoo/static/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) > template-vanilla-ts 1`] = `
+[
+  {
+    "content": "# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+",
+    "path": "README.md",
+  },
+  {
+    "content": "node_modules
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+",
+    "path": ".gitignore",
+  },
+  {
+    "content": "{
+	\\"scripts\\": {
+		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
+		\\"build\\": \\"bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]\\",
+		\\"typecheck\\": \\"tsc --noEmit\\"
+	},
+	\\"dependencies\\": {},
+	\\"devDependencies\\": {
+		\\"@anywidget/types\\": \\"0.1.4\\",
+		\\"typescript\\": \\"^5.2.2\\"
+	}
+}",
+    "path": "package.json",
+  },
+  {
+    "content": "[build-system]
+requires = [\\"hatchling\\"]
+build-backend = \\"hatchling.build\\"
+
+[project]
+name = \\"ipyfoo\\"
+version = \\"0.0.0\\"
+dependencies = [\\"anywidget\\"]
+
+[project.optional-dependencies]
+dev = [\\"watchfiles\\", \\"jupyterlab\\"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = [\\"dev\\"]
+
+
+[tool.hatch.build]
+artifacts = [\\"src/ipyfoo/static/*\\"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = \\"hatch_jupyter_builder.npm_builder\\"
+ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
+skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = \\"npm\\"
+build_cmd = \\"build\\"
+path = \\"js\\"
+",
+    "path": "pyproject.toml",
+  },
+  {
+    "content": "import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = \\"unknown\\"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.js\\"
+    _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
+    value = traitlets.Int(0).tag(sync=True)
+",
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": "import type { RenderContext } from \\"@anywidget/types\\";
+import \\"./widget.css\\";
+
+/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
+interface WidgetModel {
+	value: number;
+	/* Add your own */
+}
+
+export function render({ model, el }: RenderContext<WidgetModel>) {
+	let btn = document.createElement(\\"button\\");
+	btn.classList.add(\\"ipyfoo-counter-button\\");
+	btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
+	btn.addEventListener(\\"click\\", () => {
+		model.set(\\"value\\", model.get(\\"value\\") + 1);
+		model.save_changes();
+	});
+	model.on(\\"change:value\\", () => {
+		btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
+	});
+	el.appendChild(btn);
+}
+",
+    "path": "js/widget.ts",
+  },
+  {
+    "content": ".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: \\"Roboto\\", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+",
+    "path": "js/widget.css",
+  },
+  {
+    "content": "{
+	\\"include\\": [
+		\\"js\\"
+	],
+	\\"compilerOptions\\": {
+		\\"target\\": \\"ES2020\\",
+		\\"module\\": \\"ESNext\\",
+		\\"lib\\": [
+			\\"ES2020\\",
+			\\"DOM\\",
+			\\"DOM.Iterable\\"
+		],
+		\\"skipLibCheck\\": true,
+		\\"moduleResolution\\": \\"bundler\\",
+		\\"allowImportingTsExtensions\\": true,
+		\\"resolveJsonModule\\": true,
+		\\"isolatedModules\\": true,
+		\\"noEmit\\": true,
+		\\"jsx\\": \\"react\\",
+		\\"strict\\": true,
+		\\"noUnusedLocals\\": true,
+		\\"noUnusedParameters\\": true,
+		\\"noFallthroughCasesInSwitch\\": true
+	}
+}",
+    "path": "tsconfig.json",
+  },
+]
+`;
+
 exports[`create-anywidget > template-react 1`] = `
 [
   {

--- a/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
@@ -28,152 +28,7 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"esbuild --minify --format=esm --bundle --outdir=src/ipyfoo/static js/widget.jsx\\"
-	},
-	\\"dependencies\\": {
-		\\"@anywidget/react\\": \\"0.0.2\\",
-		\\"esbuild\\": \\"^0.19.2\\",
-		\\"react\\": \\"^18.2.0\\",
-		\\"react-dom\\": \\"^18.2.0\\"
-	},
-	\\"devDependencies\\": {}
-}",
-    "path": "package.json",
-  },
-  {
-    "content": "[build-system]
-requires = [\\"hatchling\\"]
-build-backend = \\"hatchling.build\\"
-
-[project]
-name = \\"ipyfoo\\"
-version = \\"0.0.0\\"
-dependencies = [\\"anywidget\\"]
-
-[project.optional-dependencies]
-dev = [\\"watchfiles\\", \\"jupyterlab\\"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = [\\"dev\\"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = [\\"src/ipyfoo/static/*\\"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = \\"hatch_jupyter_builder.npm_builder\\"
-ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
-skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
-dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = \\"npm\\"
-build_cmd = \\"build\\"
-path = \\"js\\"
-",
-    "path": "pyproject.toml",
-  },
-  {
-    "content": "import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = \\"unknown\\"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.js\\"
-    _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
-    value = traitlets.Int(0).tag(sync=True)
-",
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": "import * as React from \\"react\\";
-import { createRender, useModelState } from \\"@anywidget/react\\";
-import \\"./styles.css\\";
-
-export const render = createRender(() => {
-	const [value, setValue] = useModelState(\\"value\\");
-	return (
-		<button
-			className=\\"ipyfoo-counter-button\\"
-			onClick={() => setValue(value + 1)}
-		>
-			count is {value}
-		</button>
-	);
-});
-",
-    "path": "js/widget.jsx",
-  },
-  {
-    "content": ".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: \\"Roboto\\", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-",
-    "path": "js/styles.css",
-  },
-]
-`;
-
-exports[`create-anywidget > template-react-ts 1`] = `
-[
-  {
-    "content": "# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-",
-    "path": "README.md",
-  },
-  {
-    "content": "node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-",
-    "path": ".gitignore",
-  },
-  {
-    "content": "{
-	\\"scripts\\": {
-		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"esbuild --minify --format=esm --bundle --outdir=src/ipyfoo/static js/widget.tsx\\",
-		\\"typecheck\\": \\"tsc --noEmit\\"
+		\\"build\\": \\"esbuild js/widget.jsx --minify --format=esm --bundle --outdir=src/ipyfoo/static\\"
 	},
 	\\"dependencies\\": {
 		\\"@anywidget/react\\": \\"0.0.2\\",
@@ -181,10 +36,7 @@ src/ipyfoo/static
 		\\"react-dom\\": \\"^18.2.0\\"
 	},
 	\\"devDependencies\\": {
-		\\"@types/react\\": \\"^18.2.21\\",
-		\\"@types/react-dom\\": \\"^18.2.7\\",
-		\\"esbuild\\": \\"^0.19.2\\",
-		\\"typescript\\": \\"^5.2.2\\"
+		\\"esbuild\\": \\"^0.19.2\\"
 	}
 }",
     "path": "package.json",
@@ -247,7 +99,156 @@ class Counter(anywidget.AnyWidget):
   {
     "content": "import * as React from \\"react\\";
 import { createRender, useModelState } from \\"@anywidget/react\\";
-import \\"./styles.css\\";
+import \\"./widget.css\\";
+
+export const render = createRender(() => {
+	const [value, setValue] = useModelState(\\"value\\");
+	return (
+		<button
+			className=\\"ipyfoo-counter-button\\"
+			onClick={() => setValue(value + 1)}
+		>
+			count is {value}
+		</button>
+	);
+});
+",
+    "path": "js/widget.jsx",
+  },
+  {
+    "content": ".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: \\"Roboto\\", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+",
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget > template-react-ts 1`] = `
+[
+  {
+    "content": "# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+",
+    "path": "README.md",
+  },
+  {
+    "content": "node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+",
+    "path": ".gitignore",
+  },
+  {
+    "content": "{
+	\\"scripts\\": {
+		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
+		\\"build\\": \\"esbuild js/widget.tsx --minify --format=esm --bundle --outdir=src/ipyfoo/static\\",
+		\\"typecheck\\": \\"tsc --noEmit\\"
+	},
+	\\"dependencies\\": {
+		\\"@anywidget/react\\": \\"0.0.2\\",
+		\\"react\\": \\"^18.2.0\\",
+		\\"react-dom\\": \\"^18.2.0\\"
+	},
+	\\"devDependencies\\": {
+		\\"@types/react\\": \\"^18.2.21\\",
+		\\"@types/react-dom\\": \\"^18.2.7\\",
+		\\"typescript\\": \\"^5.2.2\\",
+		\\"esbuild\\": \\"^0.19.2\\"
+	}
+}",
+    "path": "package.json",
+  },
+  {
+    "content": "[build-system]
+requires = [\\"hatchling\\"]
+build-backend = \\"hatchling.build\\"
+
+[project]
+name = \\"ipyfoo\\"
+version = \\"0.0.0\\"
+dependencies = [\\"anywidget\\"]
+
+[project.optional-dependencies]
+dev = [\\"watchfiles\\", \\"jupyterlab\\"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = [\\"dev\\"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = [\\"src/ipyfoo/static/*\\"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = \\"hatch_jupyter_builder.npm_builder\\"
+ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
+skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = \\"npm\\"
+build_cmd = \\"build\\"
+path = \\"js\\"
+",
+    "path": "pyproject.toml",
+  },
+  {
+    "content": "import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = \\"unknown\\"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.js\\"
+    _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
+    value = traitlets.Int(0).tag(sync=True)
+",
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": "import * as React from \\"react\\";
+import { createRender, useModelState } from \\"@anywidget/react\\";
+import \\"./widget.css\\";
 
 export const render = createRender(() => {
 	const [value, setValue] = useModelState<number>(\\"value\\");
@@ -288,7 +289,7 @@ export const render = createRender(() => {
 	transform: scale(1.05);
 }
 ",
-    "path": "js/styles.css",
+    "path": "js/widget.css",
   },
   {
     "content": "{
@@ -349,7 +350,7 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"esbuild --minify --format=esm --bundle --outdir=src/ipyfoo/static js/widget.js\\"
+		\\"build\\": \\"esbuild js/widget.js --minify --format=esm --bundle --outdir=src/ipyfoo/static\\"
 	},
 	\\"dependencies\\": {},
 	\\"devDependencies\\": {
@@ -414,7 +415,7 @@ class Counter(anywidget.AnyWidget):
     "path": "src/ipyfoo/__init__.py",
   },
   {
-    "content": "import \\"./styles.css\\";
+    "content": "import \\"./widget.css\\";
 
 export function render({ model, el }) {
 	let btn = document.createElement(\\"button\\");
@@ -457,7 +458,7 @@ export function render({ model, el }) {
 	transform: scale(1.05);
 }
 ",
-    "path": "js/styles.css",
+    "path": "js/widget.css",
   },
 ]
 `;
@@ -598,7 +599,7 @@ export function render({ model, el }) {
 	transform: scale(1.05);
 }
 ",
-    "path": "src/ipyfoo/static/styles.css",
+    "path": "src/ipyfoo/static/widget.css",
   },
 ]
 `;
@@ -631,14 +632,14 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"esbuild --minify --format=esm --bundle --outdir=src/ipyfoo/static js/widget.ts\\",
+		\\"build\\": \\"esbuild js/widget.ts --minify --format=esm --bundle --outdir=src/ipyfoo/static\\",
 		\\"typecheck\\": \\"tsc --noEmit\\"
 	},
 	\\"dependencies\\": {},
 	\\"devDependencies\\": {
 		\\"@anywidget/types\\": \\"0.1.4\\",
-		\\"esbuild\\": \\"^0.19.2\\",
-		\\"typescript\\": \\"^5.2.2\\"
+		\\"typescript\\": \\"^5.2.2\\",
+		\\"esbuild\\": \\"^0.19.2\\"
 	}
 }",
     "path": "package.json",
@@ -700,7 +701,7 @@ class Counter(anywidget.AnyWidget):
   },
   {
     "content": "import type { RenderContext } from \\"@anywidget/types\\";
-import \\"./styles.css\\";
+import \\"./widget.css\\";
 
 /* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
 interface WidgetModel {
@@ -749,7 +750,7 @@ export function render({ model, el }: RenderContext<WidgetModel>) {
 	transform: scale(1.05);
 }
 ",
-    "path": "js/styles.css",
+    "path": "js/widget.css",
   },
   {
     "content": "{

--- a/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
@@ -1559,3 +1559,3713 @@ export function render({ model, el }: RenderContext<WidgetModel>) {
   },
 ]
 `;
+
+exports[`create-anywidget template-vanilla 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
+	},
+	"dependencies": {},
+	"devDependencies": {}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import "./widget.css";
+
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla-ts 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {},
+	"devDependencies": {
+		"@anywidget/types": "0.1.4",
+		"typescript": "^5.2.2"
+	}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import type { RenderContext } from "@anywidget/types";
+import "./widget.css";
+
+/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
+interface WidgetModel {
+	value: number;
+	/* Add your own */
+}
+
+export function render({ model, el }: RenderContext<WidgetModel>) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.ts",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+  {
+    "content": 
+"{
+	"include": [
+		"js"
+	],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react",
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	}
+}"
+,
+    "path": "tsconfig.json",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla-deno-jsdoc 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"{
+	"lock": false,
+	"compilerOptions": {
+		"checkJs": true,
+		"allowJs": true,
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		]
+	},
+	"fmt": {
+		"useTabs": true
+	},
+	"lint": {
+		"rules": {
+			"exclude": [
+				"prefer-const"
+			]
+		}
+	}
+}"
+,
+    "path": "deno.json",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import confetti from "https://esm.sh/canvas-confetti@1";
+
+/** @typedef {{ value: number }} Model */
+
+/** @type {import("npm:@anywidget/types").Render<Model>} */
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		confetti();
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget template-react 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.jsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
+	},
+	"dependencies": {
+		"@anywidget/react": "0.0.2",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0"
+	},
+	"devDependencies": {}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import * as React from "react";
+import { createRender, useModelState } from "@anywidget/react";
+import "./widget.css";
+
+export const render = createRender(() => {
+	const [value, setValue] = useModelState("value");
+	return (
+		<button
+			className="ipyfoo-counter-button"
+			onClick={() => setValue(value + 1)}
+		>
+			count is {value}
+		</button>
+	);
+});
+"
+,
+    "path": "js/widget.jsx",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget template-react-ts 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.tsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@anywidget/react": "0.0.2",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0"
+	},
+	"devDependencies": {
+		"@types/react": "^18.2.21",
+		"@types/react-dom": "^18.2.7",
+		"typescript": "^5.2.2"
+	}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import * as React from "react";
+import { createRender, useModelState } from "@anywidget/react";
+import "./widget.css";
+
+export const render = createRender(() => {
+	const [value, setValue] = useModelState<number>("value");
+	return (
+		<button
+			className="ipyfoo-counter-button"
+			onClick={() => setValue(value + 1)}
+		>
+			count is {value}
+		</button>
+	);
+});
+"
+,
+    "path": "js/widget.tsx",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+  {
+    "content": 
+"{
+	"include": [
+		"js"
+	],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react",
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	}
+}"
+,
+    "path": "tsconfig.json",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
+	},
+	"dependencies": {},
+	"devDependencies": {}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import "./widget.css";
+
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla-ts 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {},
+	"devDependencies": {
+		"@anywidget/types": "0.1.4",
+		"typescript": "^5.2.2"
+	}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import type { RenderContext } from "@anywidget/types";
+import "./widget.css";
+
+/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
+interface WidgetModel {
+	value: number;
+	/* Add your own */
+}
+
+export function render({ model, el }: RenderContext<WidgetModel>) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.ts",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+  {
+    "content": 
+"{
+	"include": [
+		"js"
+	],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react",
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	}
+}"
+,
+    "path": "tsconfig.json",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla-deno-jsdoc 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"{
+	"lock": false,
+	"compilerOptions": {
+		"checkJs": true,
+		"allowJs": true,
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		]
+	},
+	"fmt": {
+		"useTabs": true
+	},
+	"lint": {
+		"rules": {
+			"exclude": [
+				"prefer-const"
+			]
+		}
+	}
+}"
+,
+    "path": "deno.json",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import confetti from "https://esm.sh/canvas-confetti@1";
+
+/** @typedef {{ value: number }} Model */
+
+/** @type {import("npm:@anywidget/types").Render<Model>} */
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		confetti();
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
+	},
+	"dependencies": {},
+	"devDependencies": {}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import "./widget.css";
+
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla-ts 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {},
+	"devDependencies": {
+		"@anywidget/types": "0.1.4",
+		"typescript": "^5.2.2"
+	}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import type { RenderContext } from "@anywidget/types";
+import "./widget.css";
+
+/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
+interface WidgetModel {
+	value: number;
+	/* Add your own */
+}
+
+export function render({ model, el }: RenderContext<WidgetModel>) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.ts",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+  {
+    "content": 
+"{
+	"include": [
+		"js"
+	],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react",
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	}
+}"
+,
+    "path": "tsconfig.json",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla-deno-jsdoc 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"{
+	"lock": false,
+	"compilerOptions": {
+		"checkJs": true,
+		"allowJs": true,
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		]
+	},
+	"fmt": {
+		"useTabs": true
+	},
+	"lint": {
+		"rules": {
+			"exclude": [
+				"prefer-const"
+			]
+		}
+	}
+}"
+,
+    "path": "deno.json",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import confetti from "https://esm.sh/canvas-confetti@1";
+
+/** @typedef {{ value: number }} Model */
+
+/** @type {import("npm:@anywidget/types").Render<Model>} */
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		confetti();
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) template-vanilla 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
+	},
+	"dependencies": {},
+	"devDependencies": {}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import "./widget.css";
+
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) template-vanilla-ts 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {},
+	"devDependencies": {
+		"@anywidget/types": "0.1.4",
+		"typescript": "^5.2.2"
+	}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import type { RenderContext } from "@anywidget/types";
+import "./widget.css";
+
+/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
+interface WidgetModel {
+	value: number;
+	/* Add your own */
+}
+
+export function render({ model, el }: RenderContext<WidgetModel>) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.ts",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+  {
+    "content": 
+"{
+	"include": [
+		"js"
+	],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react",
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	}
+}"
+,
+    "path": "tsconfig.json",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) template-vanilla-deno-jsdoc 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"{
+	"lock": false,
+	"compilerOptions": {
+		"checkJs": true,
+		"allowJs": true,
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		]
+	},
+	"fmt": {
+		"useTabs": true
+	},
+	"lint": {
+		"rules": {
+			"exclude": [
+				"prefer-const"
+			]
+		}
+	}
+}"
+,
+    "path": "deno.json",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import confetti from "https://esm.sh/canvas-confetti@1";
+
+/** @typedef {{ value: number }} Model */
+
+/** @type {import("npm:@anywidget/types").Render<Model>} */
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		confetti();
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) template-react 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.jsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
+	},
+	"dependencies": {
+		"@anywidget/react": "0.0.2",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0"
+	},
+	"devDependencies": {}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import * as React from "react";
+import { createRender, useModelState } from "@anywidget/react";
+import "./widget.css";
+
+export const render = createRender(() => {
+	const [value, setValue] = useModelState("value");
+	return (
+		<button
+			className="ipyfoo-counter-button"
+			onClick={() => setValue(value + 1)}
+		>
+			count is {value}
+		</button>
+	);
+});
+"
+,
+    "path": "js/widget.jsx",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) template-react-ts 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.tsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@anywidget/react": "0.0.2",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0"
+	},
+	"devDependencies": {
+		"@types/react": "^18.2.21",
+		"@types/react-dom": "^18.2.7",
+		"typescript": "^5.2.2"
+	}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import * as React from "react";
+import { createRender, useModelState } from "@anywidget/react";
+import "./widget.css";
+
+export const render = createRender(() => {
+	const [value, setValue] = useModelState<number>("value");
+	return (
+		<button
+			className="ipyfoo-counter-button"
+			onClick={() => setValue(value + 1)}
+		>
+			count is {value}
+		</button>
+	);
+});
+"
+,
+    "path": "js/widget.tsx",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+  {
+    "content": 
+"{
+	"include": [
+		"js"
+	],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react",
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	}
+}"
+,
+    "path": "tsconfig.json",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
+	},
+	"dependencies": {},
+	"devDependencies": {}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import "./widget.css";
+
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla-ts 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {},
+	"devDependencies": {
+		"@anywidget/types": "0.1.4",
+		"typescript": "^5.2.2"
+	}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import type { RenderContext } from "@anywidget/types";
+import "./widget.css";
+
+/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
+interface WidgetModel {
+	value: number;
+	/* Add your own */
+}
+
+export function render({ model, el }: RenderContext<WidgetModel>) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.ts",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+  {
+    "content": 
+"{
+	"include": [
+		"js"
+	],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react",
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	}
+}"
+,
+    "path": "tsconfig.json",
+  },
+]
+`;
+
+exports[`create-anywidget template-vanilla-deno-jsdoc 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"{
+	"lock": false,
+	"compilerOptions": {
+		"checkJs": true,
+		"allowJs": true,
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		]
+	},
+	"fmt": {
+		"useTabs": true
+	},
+	"lint": {
+		"rules": {
+			"exclude": [
+				"prefer-const"
+			]
+		}
+	}
+}"
+,
+    "path": "deno.json",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import confetti from "https://esm.sh/canvas-confetti@1";
+
+/** @typedef {{ value: number }} Model */
+
+/** @type {import("npm:@anywidget/types").Render<Model>} */
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		confetti();
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) template-vanilla 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
+	},
+	"dependencies": {},
+	"devDependencies": {}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import "./widget.css";
+
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) template-vanilla-ts 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+src/ipyfoo/static
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"{
+	"scripts": {
+		"dev": "npm run build -- --sourcemap=inline --watch",
+		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {},
+	"devDependencies": {
+		"@anywidget/types": "0.1.4",
+		"typescript": "^5.2.2"
+	}
+}"
+,
+    "path": "package.json",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+
+
+[tool.hatch.build]
+only-packages = true
+artifacts = ["src/ipyfoo/static/*"]
+
+[tool.hatch.build.hooks.jupyter-builder]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = ["src/ipyfoo/static/widget.js"]
+skip-if-exists = ["src/ipyfoo/static/widget.js"]
+dependencies = ["hatch-jupyter-builder>=0.5.0"]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+npm = "npm"
+build_cmd = "build"
+path = "js"
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import type { RenderContext } from "@anywidget/types";
+import "./widget.css";
+
+/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
+interface WidgetModel {
+	value: number;
+	/* Add your own */
+}
+
+export function render({ model, el }: RenderContext<WidgetModel>) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "js/widget.ts",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "js/widget.css",
+  },
+  {
+    "content": 
+"{
+	"include": [
+		"js"
+	],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react",
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	}
+}"
+,
+    "path": "tsconfig.json",
+  },
+]
+`;
+
+exports[`create-anywidget (Bun) template-vanilla-deno-jsdoc 1`] = `
+[
+  {
+    "content": 
+"# ipyfoo
+
+\`\`\`sh
+pip install ipyfoo
+\`\`\`
+"
+,
+    "path": "README.md",
+  },
+  {
+    "content": 
+"[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ipyfoo"
+version = "0.0.0"
+dependencies = ["anywidget"]
+
+[project.optional-dependencies]
+dev = ["watchfiles", "jupyterlab"]
+
+# automatically add the dev feature to the default env (e.g., hatch shell)
+[tool.hatch.envs.default]
+features = ["dev"]
+"
+,
+    "path": "pyproject.toml",
+  },
+  {
+    "content": 
+"{
+	"lock": false,
+	"compilerOptions": {
+		"checkJs": true,
+		"allowJs": true,
+		"lib": [
+			"ES2020",
+			"DOM",
+			"DOM.Iterable"
+		]
+	},
+	"fmt": {
+		"useTabs": true
+	},
+	"lint": {
+		"rules": {
+			"exclude": [
+				"prefer-const"
+			]
+		}
+	}
+}"
+,
+    "path": "deno.json",
+  },
+  {
+    "content": 
+"node_modules
+.venv
+dist
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+
+"
+,
+    "path": ".gitignore",
+  },
+  {
+    "content": 
+"import importlib.metadata
+import pathlib
+
+import anywidget
+import traitlets
+
+try:
+    __version__ = importlib.metadata.version("ipyfoo")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+
+
+class Counter(anywidget.AnyWidget):
+    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
+    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
+    value = traitlets.Int(0).tag(sync=True)
+"
+,
+    "path": "src/ipyfoo/__init__.py",
+  },
+  {
+    "content": 
+"import confetti from "https://esm.sh/canvas-confetti@1";
+
+/** @typedef {{ value: number }} Model */
+
+/** @type {import("npm:@anywidget/types").Render<Model>} */
+export function render({ model, el }) {
+	let btn = document.createElement("button");
+	btn.classList.add("ipyfoo-counter-button");
+	btn.innerHTML = \`count is ${model.get("value")}\`;
+	btn.addEventListener("click", () => {
+		model.set("value", model.get("value") + 1);
+		model.save_changes();
+	});
+	model.on("change:value", () => {
+		confetti();
+		btn.innerHTML = \`count is ${model.get("value")}\`;
+	});
+	el.appendChild(btn);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.js",
+  },
+  {
+    "content": 
+".ipyfoo-counter-button {
+	background: linear-gradient(
+		300deg,
+		#9933ff 33.26%,
+		#ff6666 46.51%,
+		#faca30 59.77%,
+		#00cd99 73.03%,
+		#00ccff 86.29%
+	);
+	border-radius: 10px;
+	border: 0;
+	color: white;
+	cursor: pointer;
+	font-family: "Roboto", sans-serif;
+	font-size: 2em;
+	margin: 10px;
+	padding: 10px 20px;
+	transition: transform 0.25s ease-in-out;
+}
+
+.ipyfoo-counter-button:hover {
+	transform: scale(1.05);
+}
+"
+,
+    "path": "src/ipyfoo/static/widget.css",
+  },
+]
+`;

--- a/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
@@ -3,10 +3,10 @@
 exports[`create-anywidget (Bun) > template-react 1`] = `
 [
   {
-    "content": "# ipyfoo
+    "content": "# undefined
 
 \`\`\`sh
-pip install ipyfoo
+pip install undefined
 \`\`\`
 ",
     "path": "README.md",
@@ -20,7 +20,7 @@ dist
 __pycache__
 .ipynb_checkpoints
 
-src/ipyfoo/static
+src/undefined/static
 ",
     "path": ".gitignore",
   },
@@ -28,7 +28,7 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"bun build js/widget.jsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]\\"
+		\\"build\\": \\"bun build js/widget.jsx --minify --format=esm --outdir=src/undefined/static --asset-naming=[name].[ext]\\"
 	},
 	\\"dependencies\\": {
 		\\"@anywidget/react\\": \\"0.0.2\\",
@@ -45,7 +45,7 @@ requires = [\\"hatchling\\"]
 build-backend = \\"hatchling.build\\"
 
 [project]
-name = \\"ipyfoo\\"
+name = \\"undefined\\"
 version = \\"0.0.0\\"
 dependencies = [\\"anywidget\\"]
 
@@ -59,18 +59,17 @@ features = [\\"dev\\"]
 
 [tool.hatch.build]
 only-packages = true
-artifacts = [\\"src/ipyfoo/static/*\\"]
+artifacts = [\\"src/undefined/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = \\"hatch_jupyter_builder.npm_builder\\"
-ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
-skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+ensured-targets = [\\"src/undefined/static/widget.js\\"]
+skip-if-exists = [\\"src/undefined/static/widget.js\\"]
 dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = \\"npm\\"
+npm = \\"undefined\\"
 build_cmd = \\"build\\"
-path = \\"js\\"
 ",
     "path": "pyproject.toml",
   },
@@ -82,7 +81,7 @@ import anywidget
 import traitlets
 
 try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+    __version__ = importlib.metadata.version(\\"undefined\\")
 except importlib.metadata.PackageNotFoundError:
     __version__ = \\"unknown\\"
 
@@ -92,7 +91,7 @@ class Counter(anywidget.AnyWidget):
     _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
     value = traitlets.Int(0).tag(sync=True)
 ",
-    "path": "src/ipyfoo/__init__.py",
+    "path": "src/undefined/__init__.py",
   },
   {
     "content": "import * as React from \\"react\\";
@@ -103,7 +102,7 @@ export const render = createRender(() => {
 	const [value, setValue] = useModelState(\\"value\\");
 	return (
 		<button
-			className=\\"ipyfoo-counter-button\\"
+			className=\\"undefined-counter-button\\"
 			onClick={() => setValue(value + 1)}
 		>
 			count is {value}
@@ -114,7 +113,7 @@ export const render = createRender(() => {
     "path": "js/widget.jsx",
   },
   {
-    "content": ".ipyfoo-counter-button {
+    "content": ".undefined-counter-button {
 	background: linear-gradient(
 		300deg,
 		#9933ff 33.26%,
@@ -134,7 +133,7 @@ export const render = createRender(() => {
 	transition: transform 0.25s ease-in-out;
 }
 
-.ipyfoo-counter-button:hover {
+.undefined-counter-button:hover {
 	transform: scale(1.05);
 }
 ",
@@ -146,10 +145,10 @@ export const render = createRender(() => {
 exports[`create-anywidget (Bun) > template-react-ts 1`] = `
 [
   {
-    "content": "# ipyfoo
+    "content": "# undefined
 
 \`\`\`sh
-pip install ipyfoo
+pip install undefined
 \`\`\`
 ",
     "path": "README.md",
@@ -163,7 +162,7 @@ dist
 __pycache__
 .ipynb_checkpoints
 
-src/ipyfoo/static
+src/undefined/static
 ",
     "path": ".gitignore",
   },
@@ -171,7 +170,7 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"bun build js/widget.tsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]\\",
+		\\"build\\": \\"bun build js/widget.tsx --minify --format=esm --outdir=src/undefined/static --asset-naming=[name].[ext]\\",
 		\\"typecheck\\": \\"tsc --noEmit\\"
 	},
 	\\"dependencies\\": {
@@ -193,7 +192,7 @@ requires = [\\"hatchling\\"]
 build-backend = \\"hatchling.build\\"
 
 [project]
-name = \\"ipyfoo\\"
+name = \\"undefined\\"
 version = \\"0.0.0\\"
 dependencies = [\\"anywidget\\"]
 
@@ -207,18 +206,17 @@ features = [\\"dev\\"]
 
 [tool.hatch.build]
 only-packages = true
-artifacts = [\\"src/ipyfoo/static/*\\"]
+artifacts = [\\"src/undefined/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = \\"hatch_jupyter_builder.npm_builder\\"
-ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
-skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+ensured-targets = [\\"src/undefined/static/widget.js\\"]
+skip-if-exists = [\\"src/undefined/static/widget.js\\"]
 dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = \\"npm\\"
+npm = \\"undefined\\"
 build_cmd = \\"build\\"
-path = \\"js\\"
 ",
     "path": "pyproject.toml",
   },
@@ -230,7 +228,7 @@ import anywidget
 import traitlets
 
 try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+    __version__ = importlib.metadata.version(\\"undefined\\")
 except importlib.metadata.PackageNotFoundError:
     __version__ = \\"unknown\\"
 
@@ -240,7 +238,7 @@ class Counter(anywidget.AnyWidget):
     _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
     value = traitlets.Int(0).tag(sync=True)
 ",
-    "path": "src/ipyfoo/__init__.py",
+    "path": "src/undefined/__init__.py",
   },
   {
     "content": "import * as React from \\"react\\";
@@ -251,7 +249,7 @@ export const render = createRender(() => {
 	const [value, setValue] = useModelState<number>(\\"value\\");
 	return (
 		<button
-			className=\\"ipyfoo-counter-button\\"
+			className=\\"undefined-counter-button\\"
 			onClick={() => setValue(value + 1)}
 		>
 			count is {value}
@@ -262,7 +260,7 @@ export const render = createRender(() => {
     "path": "js/widget.tsx",
   },
   {
-    "content": ".ipyfoo-counter-button {
+    "content": ".undefined-counter-button {
 	background: linear-gradient(
 		300deg,
 		#9933ff 33.26%,
@@ -282,7 +280,7 @@ export const render = createRender(() => {
 	transition: transform 0.25s ease-in-out;
 }
 
-.ipyfoo-counter-button:hover {
+.undefined-counter-button:hover {
 	transform: scale(1.05);
 }
 ",
@@ -322,10 +320,10 @@ export const render = createRender(() => {
 exports[`create-anywidget (Bun) > template-vanilla 1`] = `
 [
   {
-    "content": "# ipyfoo
+    "content": "# undefined
 
 \`\`\`sh
-pip install ipyfoo
+pip install undefined
 \`\`\`
 ",
     "path": "README.md",
@@ -339,7 +337,7 @@ dist
 __pycache__
 .ipynb_checkpoints
 
-src/ipyfoo/static
+src/undefined/static
 ",
     "path": ".gitignore",
   },
@@ -347,7 +345,7 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]\\"
+		\\"build\\": \\"bun build js/widget.js --minify --format=esm --outdir=src/undefined/static --asset-naming=[name].[ext]\\"
 	},
 	\\"dependencies\\": {},
 	\\"devDependencies\\": {}
@@ -360,7 +358,7 @@ requires = [\\"hatchling\\"]
 build-backend = \\"hatchling.build\\"
 
 [project]
-name = \\"ipyfoo\\"
+name = \\"undefined\\"
 version = \\"0.0.0\\"
 dependencies = [\\"anywidget\\"]
 
@@ -374,18 +372,17 @@ features = [\\"dev\\"]
 
 [tool.hatch.build]
 only-packages = true
-artifacts = [\\"src/ipyfoo/static/*\\"]
+artifacts = [\\"src/undefined/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = \\"hatch_jupyter_builder.npm_builder\\"
-ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
-skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+ensured-targets = [\\"src/undefined/static/widget.js\\"]
+skip-if-exists = [\\"src/undefined/static/widget.js\\"]
 dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = \\"npm\\"
+npm = \\"undefined\\"
 build_cmd = \\"build\\"
-path = \\"js\\"
 ",
     "path": "pyproject.toml",
   },
@@ -397,7 +394,7 @@ import anywidget
 import traitlets
 
 try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+    __version__ = importlib.metadata.version(\\"undefined\\")
 except importlib.metadata.PackageNotFoundError:
     __version__ = \\"unknown\\"
 
@@ -407,14 +404,14 @@ class Counter(anywidget.AnyWidget):
     _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
     value = traitlets.Int(0).tag(sync=True)
 ",
-    "path": "src/ipyfoo/__init__.py",
+    "path": "src/undefined/__init__.py",
   },
   {
     "content": "import \\"./widget.css\\";
 
 export function render({ model, el }) {
 	let btn = document.createElement(\\"button\\");
-	btn.classList.add(\\"ipyfoo-counter-button\\");
+	btn.classList.add(\\"undefined-counter-button\\");
 	btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
 	btn.addEventListener(\\"click\\", () => {
 		model.set(\\"value\\", model.get(\\"value\\") + 1);
@@ -429,7 +426,7 @@ export function render({ model, el }) {
     "path": "js/widget.js",
   },
   {
-    "content": ".ipyfoo-counter-button {
+    "content": ".undefined-counter-button {
 	background: linear-gradient(
 		300deg,
 		#9933ff 33.26%,
@@ -449,7 +446,7 @@ export function render({ model, el }) {
 	transition: transform 0.25s ease-in-out;
 }
 
-.ipyfoo-counter-button:hover {
+.undefined-counter-button:hover {
 	transform: scale(1.05);
 }
 ",
@@ -461,10 +458,10 @@ export function render({ model, el }) {
 exports[`create-anywidget (Bun) > template-vanilla-deno-jsdoc 1`] = `
 [
   {
-    "content": "# ipyfoo
+    "content": "# undefined
 
 \`\`\`sh
-pip install ipyfoo
+pip install undefined
 \`\`\`
 ",
     "path": "README.md",
@@ -475,7 +472,7 @@ requires = [\\"hatchling\\"]
 build-backend = \\"hatchling.build\\"
 
 [project]
-name = \\"ipyfoo\\"
+name = \\"undefined\\"
 version = \\"0.0.0\\"
 dependencies = [\\"anywidget\\"]
 
@@ -534,7 +531,7 @@ import anywidget
 import traitlets
 
 try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+    __version__ = importlib.metadata.version(\\"undefined\\")
 except importlib.metadata.PackageNotFoundError:
     __version__ = \\"unknown\\"
 
@@ -544,7 +541,7 @@ class Counter(anywidget.AnyWidget):
     _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
     value = traitlets.Int(0).tag(sync=True)
 ",
-    "path": "src/ipyfoo/__init__.py",
+    "path": "src/undefined/__init__.py",
   },
   {
     "content": "import confetti from \\"https://esm.sh/canvas-confetti@1\\";
@@ -554,7 +551,7 @@ class Counter(anywidget.AnyWidget):
 /** @type {import(\\"npm:@anywidget/types\\").Render<Model>} */
 export function render({ model, el }) {
 	let btn = document.createElement(\\"button\\");
-	btn.classList.add(\\"ipyfoo-counter-button\\");
+	btn.classList.add(\\"undefined-counter-button\\");
 	btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
 	btn.addEventListener(\\"click\\", () => {
 		model.set(\\"value\\", model.get(\\"value\\") + 1);
@@ -567,10 +564,10 @@ export function render({ model, el }) {
 	el.appendChild(btn);
 }
 ",
-    "path": "src/ipyfoo/static/widget.js",
+    "path": "src/undefined/static/widget.js",
   },
   {
-    "content": ".ipyfoo-counter-button {
+    "content": ".undefined-counter-button {
 	background: linear-gradient(
 		300deg,
 		#9933ff 33.26%,
@@ -590,11 +587,11 @@ export function render({ model, el }) {
 	transition: transform 0.25s ease-in-out;
 }
 
-.ipyfoo-counter-button:hover {
+.undefined-counter-button:hover {
 	transform: scale(1.05);
 }
 ",
-    "path": "src/ipyfoo/static/widget.css",
+    "path": "src/undefined/static/widget.css",
   },
 ]
 `;
@@ -602,10 +599,10 @@ export function render({ model, el }) {
 exports[`create-anywidget (Bun) > template-vanilla-ts 1`] = `
 [
   {
-    "content": "# ipyfoo
+    "content": "# undefined
 
 \`\`\`sh
-pip install ipyfoo
+pip install undefined
 \`\`\`
 ",
     "path": "README.md",
@@ -619,7 +616,7 @@ dist
 __pycache__
 .ipynb_checkpoints
 
-src/ipyfoo/static
+src/undefined/static
 ",
     "path": ".gitignore",
   },
@@ -627,7 +624,7 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]\\",
+		\\"build\\": \\"bun build js/widget.ts --minify --format=esm --outdir=src/undefined/static --asset-naming=[name].[ext]\\",
 		\\"typecheck\\": \\"tsc --noEmit\\"
 	},
 	\\"dependencies\\": {},
@@ -644,7 +641,7 @@ requires = [\\"hatchling\\"]
 build-backend = \\"hatchling.build\\"
 
 [project]
-name = \\"ipyfoo\\"
+name = \\"undefined\\"
 version = \\"0.0.0\\"
 dependencies = [\\"anywidget\\"]
 
@@ -658,18 +655,17 @@ features = [\\"dev\\"]
 
 [tool.hatch.build]
 only-packages = true
-artifacts = [\\"src/ipyfoo/static/*\\"]
+artifacts = [\\"src/undefined/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = \\"hatch_jupyter_builder.npm_builder\\"
-ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
-skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+ensured-targets = [\\"src/undefined/static/widget.js\\"]
+skip-if-exists = [\\"src/undefined/static/widget.js\\"]
 dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = \\"npm\\"
+npm = \\"undefined\\"
 build_cmd = \\"build\\"
-path = \\"js\\"
 ",
     "path": "pyproject.toml",
   },
@@ -681,7 +677,7 @@ import anywidget
 import traitlets
 
 try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+    __version__ = importlib.metadata.version(\\"undefined\\")
 except importlib.metadata.PackageNotFoundError:
     __version__ = \\"unknown\\"
 
@@ -691,13 +687,13 @@ class Counter(anywidget.AnyWidget):
     _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
     value = traitlets.Int(0).tag(sync=True)
 ",
-    "path": "src/ipyfoo/__init__.py",
+    "path": "src/undefined/__init__.py",
   },
   {
     "content": "import type { RenderContext } from \\"@anywidget/types\\";
 import \\"./widget.css\\";
 
-/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
+/* Specifies attributes defined with traitlets in ../src/undefined/__init__.py */
 interface WidgetModel {
 	value: number;
 	/* Add your own */
@@ -705,7 +701,7 @@ interface WidgetModel {
 
 export function render({ model, el }: RenderContext<WidgetModel>) {
 	let btn = document.createElement(\\"button\\");
-	btn.classList.add(\\"ipyfoo-counter-button\\");
+	btn.classList.add(\\"undefined-counter-button\\");
 	btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
 	btn.addEventListener(\\"click\\", () => {
 		model.set(\\"value\\", model.get(\\"value\\") + 1);
@@ -720,7 +716,7 @@ export function render({ model, el }: RenderContext<WidgetModel>) {
     "path": "js/widget.ts",
   },
   {
-    "content": ".ipyfoo-counter-button {
+    "content": ".undefined-counter-button {
 	background: linear-gradient(
 		300deg,
 		#9933ff 33.26%,
@@ -740,7 +736,7 @@ export function render({ model, el }: RenderContext<WidgetModel>) {
 	transition: transform 0.25s ease-in-out;
 }
 
-.ipyfoo-counter-button:hover {
+.undefined-counter-button:hover {
 	transform: scale(1.05);
 }
 ",
@@ -780,10 +776,10 @@ export function render({ model, el }: RenderContext<WidgetModel>) {
 exports[`create-anywidget > template-react 1`] = `
 [
   {
-    "content": "# ipyfoo
+    "content": "# undefined
 
 \`\`\`sh
-pip install ipyfoo
+pip install undefined
 \`\`\`
 ",
     "path": "README.md",
@@ -797,7 +793,7 @@ dist
 __pycache__
 .ipynb_checkpoints
 
-src/ipyfoo/static
+src/undefined/static
 ",
     "path": ".gitignore",
   },
@@ -805,7 +801,7 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"esbuild js/widget.jsx --minify --format=esm --bundle --outdir=src/ipyfoo/static\\"
+		\\"build\\": \\"esbuild js/widget.jsx --minify --format=esm --bundle --outdir=src/undefined/static\\"
 	},
 	\\"dependencies\\": {
 		\\"@anywidget/react\\": \\"0.0.2\\",
@@ -824,7 +820,7 @@ requires = [\\"hatchling\\"]
 build-backend = \\"hatchling.build\\"
 
 [project]
-name = \\"ipyfoo\\"
+name = \\"undefined\\"
 version = \\"0.0.0\\"
 dependencies = [\\"anywidget\\"]
 
@@ -838,18 +834,17 @@ features = [\\"dev\\"]
 
 [tool.hatch.build]
 only-packages = true
-artifacts = [\\"src/ipyfoo/static/*\\"]
+artifacts = [\\"src/undefined/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = \\"hatch_jupyter_builder.npm_builder\\"
-ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
-skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+ensured-targets = [\\"src/undefined/static/widget.js\\"]
+skip-if-exists = [\\"src/undefined/static/widget.js\\"]
 dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = \\"npm\\"
+npm = \\"undefined\\"
 build_cmd = \\"build\\"
-path = \\"js\\"
 ",
     "path": "pyproject.toml",
   },
@@ -861,7 +856,7 @@ import anywidget
 import traitlets
 
 try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+    __version__ = importlib.metadata.version(\\"undefined\\")
 except importlib.metadata.PackageNotFoundError:
     __version__ = \\"unknown\\"
 
@@ -871,7 +866,7 @@ class Counter(anywidget.AnyWidget):
     _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
     value = traitlets.Int(0).tag(sync=True)
 ",
-    "path": "src/ipyfoo/__init__.py",
+    "path": "src/undefined/__init__.py",
   },
   {
     "content": "import * as React from \\"react\\";
@@ -882,7 +877,7 @@ export const render = createRender(() => {
 	const [value, setValue] = useModelState(\\"value\\");
 	return (
 		<button
-			className=\\"ipyfoo-counter-button\\"
+			className=\\"undefined-counter-button\\"
 			onClick={() => setValue(value + 1)}
 		>
 			count is {value}
@@ -893,7 +888,7 @@ export const render = createRender(() => {
     "path": "js/widget.jsx",
   },
   {
-    "content": ".ipyfoo-counter-button {
+    "content": ".undefined-counter-button {
 	background: linear-gradient(
 		300deg,
 		#9933ff 33.26%,
@@ -913,7 +908,7 @@ export const render = createRender(() => {
 	transition: transform 0.25s ease-in-out;
 }
 
-.ipyfoo-counter-button:hover {
+.undefined-counter-button:hover {
 	transform: scale(1.05);
 }
 ",
@@ -925,10 +920,10 @@ export const render = createRender(() => {
 exports[`create-anywidget > template-react-ts 1`] = `
 [
   {
-    "content": "# ipyfoo
+    "content": "# undefined
 
 \`\`\`sh
-pip install ipyfoo
+pip install undefined
 \`\`\`
 ",
     "path": "README.md",
@@ -942,7 +937,7 @@ dist
 __pycache__
 .ipynb_checkpoints
 
-src/ipyfoo/static
+src/undefined/static
 ",
     "path": ".gitignore",
   },
@@ -950,7 +945,7 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"esbuild js/widget.tsx --minify --format=esm --bundle --outdir=src/ipyfoo/static\\",
+		\\"build\\": \\"esbuild js/widget.tsx --minify --format=esm --bundle --outdir=src/undefined/static\\",
 		\\"typecheck\\": \\"tsc --noEmit\\"
 	},
 	\\"dependencies\\": {
@@ -973,7 +968,7 @@ requires = [\\"hatchling\\"]
 build-backend = \\"hatchling.build\\"
 
 [project]
-name = \\"ipyfoo\\"
+name = \\"undefined\\"
 version = \\"0.0.0\\"
 dependencies = [\\"anywidget\\"]
 
@@ -987,18 +982,17 @@ features = [\\"dev\\"]
 
 [tool.hatch.build]
 only-packages = true
-artifacts = [\\"src/ipyfoo/static/*\\"]
+artifacts = [\\"src/undefined/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = \\"hatch_jupyter_builder.npm_builder\\"
-ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
-skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+ensured-targets = [\\"src/undefined/static/widget.js\\"]
+skip-if-exists = [\\"src/undefined/static/widget.js\\"]
 dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = \\"npm\\"
+npm = \\"undefined\\"
 build_cmd = \\"build\\"
-path = \\"js\\"
 ",
     "path": "pyproject.toml",
   },
@@ -1010,7 +1004,7 @@ import anywidget
 import traitlets
 
 try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+    __version__ = importlib.metadata.version(\\"undefined\\")
 except importlib.metadata.PackageNotFoundError:
     __version__ = \\"unknown\\"
 
@@ -1020,7 +1014,7 @@ class Counter(anywidget.AnyWidget):
     _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
     value = traitlets.Int(0).tag(sync=True)
 ",
-    "path": "src/ipyfoo/__init__.py",
+    "path": "src/undefined/__init__.py",
   },
   {
     "content": "import * as React from \\"react\\";
@@ -1031,7 +1025,7 @@ export const render = createRender(() => {
 	const [value, setValue] = useModelState<number>(\\"value\\");
 	return (
 		<button
-			className=\\"ipyfoo-counter-button\\"
+			className=\\"undefined-counter-button\\"
 			onClick={() => setValue(value + 1)}
 		>
 			count is {value}
@@ -1042,7 +1036,7 @@ export const render = createRender(() => {
     "path": "js/widget.tsx",
   },
   {
-    "content": ".ipyfoo-counter-button {
+    "content": ".undefined-counter-button {
 	background: linear-gradient(
 		300deg,
 		#9933ff 33.26%,
@@ -1062,7 +1056,7 @@ export const render = createRender(() => {
 	transition: transform 0.25s ease-in-out;
 }
 
-.ipyfoo-counter-button:hover {
+.undefined-counter-button:hover {
 	transform: scale(1.05);
 }
 ",
@@ -1102,10 +1096,10 @@ export const render = createRender(() => {
 exports[`create-anywidget > template-vanilla 1`] = `
 [
   {
-    "content": "# ipyfoo
+    "content": "# undefined
 
 \`\`\`sh
-pip install ipyfoo
+pip install undefined
 \`\`\`
 ",
     "path": "README.md",
@@ -1119,7 +1113,7 @@ dist
 __pycache__
 .ipynb_checkpoints
 
-src/ipyfoo/static
+src/undefined/static
 ",
     "path": ".gitignore",
   },
@@ -1127,7 +1121,7 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"esbuild js/widget.js --minify --format=esm --bundle --outdir=src/ipyfoo/static\\"
+		\\"build\\": \\"esbuild js/widget.js --minify --format=esm --bundle --outdir=src/undefined/static\\"
 	},
 	\\"dependencies\\": {},
 	\\"devDependencies\\": {
@@ -1142,7 +1136,7 @@ requires = [\\"hatchling\\"]
 build-backend = \\"hatchling.build\\"
 
 [project]
-name = \\"ipyfoo\\"
+name = \\"undefined\\"
 version = \\"0.0.0\\"
 dependencies = [\\"anywidget\\"]
 
@@ -1156,18 +1150,17 @@ features = [\\"dev\\"]
 
 [tool.hatch.build]
 only-packages = true
-artifacts = [\\"src/ipyfoo/static/*\\"]
+artifacts = [\\"src/undefined/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = \\"hatch_jupyter_builder.npm_builder\\"
-ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
-skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+ensured-targets = [\\"src/undefined/static/widget.js\\"]
+skip-if-exists = [\\"src/undefined/static/widget.js\\"]
 dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = \\"npm\\"
+npm = \\"undefined\\"
 build_cmd = \\"build\\"
-path = \\"js\\"
 ",
     "path": "pyproject.toml",
   },
@@ -1179,7 +1172,7 @@ import anywidget
 import traitlets
 
 try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+    __version__ = importlib.metadata.version(\\"undefined\\")
 except importlib.metadata.PackageNotFoundError:
     __version__ = \\"unknown\\"
 
@@ -1189,14 +1182,14 @@ class Counter(anywidget.AnyWidget):
     _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
     value = traitlets.Int(0).tag(sync=True)
 ",
-    "path": "src/ipyfoo/__init__.py",
+    "path": "src/undefined/__init__.py",
   },
   {
     "content": "import \\"./widget.css\\";
 
 export function render({ model, el }) {
 	let btn = document.createElement(\\"button\\");
-	btn.classList.add(\\"ipyfoo-counter-button\\");
+	btn.classList.add(\\"undefined-counter-button\\");
 	btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
 	btn.addEventListener(\\"click\\", () => {
 		model.set(\\"value\\", model.get(\\"value\\") + 1);
@@ -1211,7 +1204,7 @@ export function render({ model, el }) {
     "path": "js/widget.js",
   },
   {
-    "content": ".ipyfoo-counter-button {
+    "content": ".undefined-counter-button {
 	background: linear-gradient(
 		300deg,
 		#9933ff 33.26%,
@@ -1231,7 +1224,7 @@ export function render({ model, el }) {
 	transition: transform 0.25s ease-in-out;
 }
 
-.ipyfoo-counter-button:hover {
+.undefined-counter-button:hover {
 	transform: scale(1.05);
 }
 ",
@@ -1243,10 +1236,10 @@ export function render({ model, el }) {
 exports[`create-anywidget > template-vanilla-deno-jsdoc 1`] = `
 [
   {
-    "content": "# ipyfoo
+    "content": "# undefined
 
 \`\`\`sh
-pip install ipyfoo
+pip install undefined
 \`\`\`
 ",
     "path": "README.md",
@@ -1257,7 +1250,7 @@ requires = [\\"hatchling\\"]
 build-backend = \\"hatchling.build\\"
 
 [project]
-name = \\"ipyfoo\\"
+name = \\"undefined\\"
 version = \\"0.0.0\\"
 dependencies = [\\"anywidget\\"]
 
@@ -1316,7 +1309,7 @@ import anywidget
 import traitlets
 
 try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+    __version__ = importlib.metadata.version(\\"undefined\\")
 except importlib.metadata.PackageNotFoundError:
     __version__ = \\"unknown\\"
 
@@ -1326,7 +1319,7 @@ class Counter(anywidget.AnyWidget):
     _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
     value = traitlets.Int(0).tag(sync=True)
 ",
-    "path": "src/ipyfoo/__init__.py",
+    "path": "src/undefined/__init__.py",
   },
   {
     "content": "import confetti from \\"https://esm.sh/canvas-confetti@1\\";
@@ -1336,7 +1329,7 @@ class Counter(anywidget.AnyWidget):
 /** @type {import(\\"npm:@anywidget/types\\").Render<Model>} */
 export function render({ model, el }) {
 	let btn = document.createElement(\\"button\\");
-	btn.classList.add(\\"ipyfoo-counter-button\\");
+	btn.classList.add(\\"undefined-counter-button\\");
 	btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
 	btn.addEventListener(\\"click\\", () => {
 		model.set(\\"value\\", model.get(\\"value\\") + 1);
@@ -1349,10 +1342,10 @@ export function render({ model, el }) {
 	el.appendChild(btn);
 }
 ",
-    "path": "src/ipyfoo/static/widget.js",
+    "path": "src/undefined/static/widget.js",
   },
   {
-    "content": ".ipyfoo-counter-button {
+    "content": ".undefined-counter-button {
 	background: linear-gradient(
 		300deg,
 		#9933ff 33.26%,
@@ -1372,11 +1365,11 @@ export function render({ model, el }) {
 	transition: transform 0.25s ease-in-out;
 }
 
-.ipyfoo-counter-button:hover {
+.undefined-counter-button:hover {
 	transform: scale(1.05);
 }
 ",
-    "path": "src/ipyfoo/static/widget.css",
+    "path": "src/undefined/static/widget.css",
   },
 ]
 `;
@@ -1384,10 +1377,10 @@ export function render({ model, el }) {
 exports[`create-anywidget > template-vanilla-ts 1`] = `
 [
   {
-    "content": "# ipyfoo
+    "content": "# undefined
 
 \`\`\`sh
-pip install ipyfoo
+pip install undefined
 \`\`\`
 ",
     "path": "README.md",
@@ -1401,7 +1394,7 @@ dist
 __pycache__
 .ipynb_checkpoints
 
-src/ipyfoo/static
+src/undefined/static
 ",
     "path": ".gitignore",
   },
@@ -1409,7 +1402,7 @@ src/ipyfoo/static
     "content": "{
 	\\"scripts\\": {
 		\\"dev\\": \\"npm run build -- --sourcemap=inline --watch\\",
-		\\"build\\": \\"esbuild js/widget.ts --minify --format=esm --bundle --outdir=src/ipyfoo/static\\",
+		\\"build\\": \\"esbuild js/widget.ts --minify --format=esm --bundle --outdir=src/undefined/static\\",
 		\\"typecheck\\": \\"tsc --noEmit\\"
 	},
 	\\"dependencies\\": {},
@@ -1427,7 +1420,7 @@ requires = [\\"hatchling\\"]
 build-backend = \\"hatchling.build\\"
 
 [project]
-name = \\"ipyfoo\\"
+name = \\"undefined\\"
 version = \\"0.0.0\\"
 dependencies = [\\"anywidget\\"]
 
@@ -1441,18 +1434,17 @@ features = [\\"dev\\"]
 
 [tool.hatch.build]
 only-packages = true
-artifacts = [\\"src/ipyfoo/static/*\\"]
+artifacts = [\\"src/undefined/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = \\"hatch_jupyter_builder.npm_builder\\"
-ensured-targets = [\\"src/ipyfoo/static/widget.js\\"]
-skip-if-exists = [\\"src/ipyfoo/static/widget.js\\"]
+ensured-targets = [\\"src/undefined/static/widget.js\\"]
+skip-if-exists = [\\"src/undefined/static/widget.js\\"]
 dependencies = [\\"hatch-jupyter-builder>=0.5.0\\"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = \\"npm\\"
+npm = \\"undefined\\"
 build_cmd = \\"build\\"
-path = \\"js\\"
 ",
     "path": "pyproject.toml",
   },
@@ -1464,7 +1456,7 @@ import anywidget
 import traitlets
 
 try:
-    __version__ = importlib.metadata.version(\\"ipyfoo\\")
+    __version__ = importlib.metadata.version(\\"undefined\\")
 except importlib.metadata.PackageNotFoundError:
     __version__ = \\"unknown\\"
 
@@ -1474,13 +1466,13 @@ class Counter(anywidget.AnyWidget):
     _css = pathlib.Path(__file__).parent / \\"static\\" / \\"widget.css\\"
     value = traitlets.Int(0).tag(sync=True)
 ",
-    "path": "src/ipyfoo/__init__.py",
+    "path": "src/undefined/__init__.py",
   },
   {
     "content": "import type { RenderContext } from \\"@anywidget/types\\";
 import \\"./widget.css\\";
 
-/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
+/* Specifies attributes defined with traitlets in ../src/undefined/__init__.py */
 interface WidgetModel {
 	value: number;
 	/* Add your own */
@@ -1488,7 +1480,7 @@ interface WidgetModel {
 
 export function render({ model, el }: RenderContext<WidgetModel>) {
 	let btn = document.createElement(\\"button\\");
-	btn.classList.add(\\"ipyfoo-counter-button\\");
+	btn.classList.add(\\"undefined-counter-button\\");
 	btn.innerHTML = \`count is \${model.get(\\"value\\")}\`;
 	btn.addEventListener(\\"click\\", () => {
 		model.set(\\"value\\", model.get(\\"value\\") + 1);
@@ -1503,7 +1495,7 @@ export function render({ model, el }: RenderContext<WidgetModel>) {
     "path": "js/widget.ts",
   },
   {
-    "content": ".ipyfoo-counter-button {
+    "content": ".undefined-counter-button {
 	background: linear-gradient(
 		300deg,
 		#9933ff 33.26%,
@@ -1523,7 +1515,7 @@ export function render({ model, el }: RenderContext<WidgetModel>) {
 	transition: transform 0.25s ease-in-out;
 }
 
-.ipyfoo-counter-button:hover {
+.undefined-counter-button:hover {
 	transform: scale(1.05);
 }
 ",
@@ -1556,3716 +1548,6 @@ export function render({ model, el }: RenderContext<WidgetModel>) {
 	}
 }",
     "path": "tsconfig.json",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
-	},
-	"dependencies": {},
-	"devDependencies": {}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import "./widget.css";
-
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla-ts 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {},
-	"devDependencies": {
-		"@anywidget/types": "0.1.4",
-		"typescript": "^5.2.2"
-	}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import type { RenderContext } from "@anywidget/types";
-import "./widget.css";
-
-/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
-interface WidgetModel {
-	value: number;
-	/* Add your own */
-}
-
-export function render({ model, el }: RenderContext<WidgetModel>) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.ts",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-  {
-    "content": 
-"{
-	"include": [
-		"js"
-	],
-	"compilerOptions": {
-		"target": "ES2020",
-		"module": "ESNext",
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		],
-		"skipLibCheck": true,
-		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react",
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
-	}
-}"
-,
-    "path": "tsconfig.json",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla-deno-jsdoc 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"{
-	"lock": false,
-	"compilerOptions": {
-		"checkJs": true,
-		"allowJs": true,
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		]
-	},
-	"fmt": {
-		"useTabs": true
-	},
-	"lint": {
-		"rules": {
-			"exclude": [
-				"prefer-const"
-			]
-		}
-	}
-}"
-,
-    "path": "deno.json",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import confetti from "https://esm.sh/canvas-confetti@1";
-
-/** @typedef {{ value: number }} Model */
-
-/** @type {import("npm:@anywidget/types").Render<Model>} */
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		confetti();
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget template-react 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.jsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
-	},
-	"dependencies": {
-		"@anywidget/react": "0.0.2",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
-	},
-	"devDependencies": {}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import * as React from "react";
-import { createRender, useModelState } from "@anywidget/react";
-import "./widget.css";
-
-export const render = createRender(() => {
-	const [value, setValue] = useModelState("value");
-	return (
-		<button
-			className="ipyfoo-counter-button"
-			onClick={() => setValue(value + 1)}
-		>
-			count is {value}
-		</button>
-	);
-});
-"
-,
-    "path": "js/widget.jsx",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget template-react-ts 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.tsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@anywidget/react": "0.0.2",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
-	},
-	"devDependencies": {
-		"@types/react": "^18.2.21",
-		"@types/react-dom": "^18.2.7",
-		"typescript": "^5.2.2"
-	}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import * as React from "react";
-import { createRender, useModelState } from "@anywidget/react";
-import "./widget.css";
-
-export const render = createRender(() => {
-	const [value, setValue] = useModelState<number>("value");
-	return (
-		<button
-			className="ipyfoo-counter-button"
-			onClick={() => setValue(value + 1)}
-		>
-			count is {value}
-		</button>
-	);
-});
-"
-,
-    "path": "js/widget.tsx",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-  {
-    "content": 
-"{
-	"include": [
-		"js"
-	],
-	"compilerOptions": {
-		"target": "ES2020",
-		"module": "ESNext",
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		],
-		"skipLibCheck": true,
-		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react",
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
-	}
-}"
-,
-    "path": "tsconfig.json",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
-	},
-	"dependencies": {},
-	"devDependencies": {}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import "./widget.css";
-
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla-ts 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {},
-	"devDependencies": {
-		"@anywidget/types": "0.1.4",
-		"typescript": "^5.2.2"
-	}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import type { RenderContext } from "@anywidget/types";
-import "./widget.css";
-
-/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
-interface WidgetModel {
-	value: number;
-	/* Add your own */
-}
-
-export function render({ model, el }: RenderContext<WidgetModel>) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.ts",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-  {
-    "content": 
-"{
-	"include": [
-		"js"
-	],
-	"compilerOptions": {
-		"target": "ES2020",
-		"module": "ESNext",
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		],
-		"skipLibCheck": true,
-		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react",
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
-	}
-}"
-,
-    "path": "tsconfig.json",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla-deno-jsdoc 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"{
-	"lock": false,
-	"compilerOptions": {
-		"checkJs": true,
-		"allowJs": true,
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		]
-	},
-	"fmt": {
-		"useTabs": true
-	},
-	"lint": {
-		"rules": {
-			"exclude": [
-				"prefer-const"
-			]
-		}
-	}
-}"
-,
-    "path": "deno.json",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import confetti from "https://esm.sh/canvas-confetti@1";
-
-/** @typedef {{ value: number }} Model */
-
-/** @type {import("npm:@anywidget/types").Render<Model>} */
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		confetti();
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
-	},
-	"dependencies": {},
-	"devDependencies": {}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import "./widget.css";
-
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla-ts 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {},
-	"devDependencies": {
-		"@anywidget/types": "0.1.4",
-		"typescript": "^5.2.2"
-	}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import type { RenderContext } from "@anywidget/types";
-import "./widget.css";
-
-/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
-interface WidgetModel {
-	value: number;
-	/* Add your own */
-}
-
-export function render({ model, el }: RenderContext<WidgetModel>) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.ts",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-  {
-    "content": 
-"{
-	"include": [
-		"js"
-	],
-	"compilerOptions": {
-		"target": "ES2020",
-		"module": "ESNext",
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		],
-		"skipLibCheck": true,
-		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react",
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
-	}
-}"
-,
-    "path": "tsconfig.json",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla-deno-jsdoc 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"{
-	"lock": false,
-	"compilerOptions": {
-		"checkJs": true,
-		"allowJs": true,
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		]
-	},
-	"fmt": {
-		"useTabs": true
-	},
-	"lint": {
-		"rules": {
-			"exclude": [
-				"prefer-const"
-			]
-		}
-	}
-}"
-,
-    "path": "deno.json",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import confetti from "https://esm.sh/canvas-confetti@1";
-
-/** @typedef {{ value: number }} Model */
-
-/** @type {import("npm:@anywidget/types").Render<Model>} */
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		confetti();
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget (Bun) template-vanilla 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
-	},
-	"dependencies": {},
-	"devDependencies": {}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import "./widget.css";
-
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget (Bun) template-vanilla-ts 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {},
-	"devDependencies": {
-		"@anywidget/types": "0.1.4",
-		"typescript": "^5.2.2"
-	}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import type { RenderContext } from "@anywidget/types";
-import "./widget.css";
-
-/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
-interface WidgetModel {
-	value: number;
-	/* Add your own */
-}
-
-export function render({ model, el }: RenderContext<WidgetModel>) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.ts",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-  {
-    "content": 
-"{
-	"include": [
-		"js"
-	],
-	"compilerOptions": {
-		"target": "ES2020",
-		"module": "ESNext",
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		],
-		"skipLibCheck": true,
-		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react",
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
-	}
-}"
-,
-    "path": "tsconfig.json",
-  },
-]
-`;
-
-exports[`create-anywidget (Bun) template-vanilla-deno-jsdoc 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"{
-	"lock": false,
-	"compilerOptions": {
-		"checkJs": true,
-		"allowJs": true,
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		]
-	},
-	"fmt": {
-		"useTabs": true
-	},
-	"lint": {
-		"rules": {
-			"exclude": [
-				"prefer-const"
-			]
-		}
-	}
-}"
-,
-    "path": "deno.json",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import confetti from "https://esm.sh/canvas-confetti@1";
-
-/** @typedef {{ value: number }} Model */
-
-/** @type {import("npm:@anywidget/types").Render<Model>} */
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		confetti();
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget (Bun) template-react 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.jsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
-	},
-	"dependencies": {
-		"@anywidget/react": "0.0.2",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
-	},
-	"devDependencies": {}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import * as React from "react";
-import { createRender, useModelState } from "@anywidget/react";
-import "./widget.css";
-
-export const render = createRender(() => {
-	const [value, setValue] = useModelState("value");
-	return (
-		<button
-			className="ipyfoo-counter-button"
-			onClick={() => setValue(value + 1)}
-		>
-			count is {value}
-		</button>
-	);
-});
-"
-,
-    "path": "js/widget.jsx",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget (Bun) template-react-ts 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.tsx --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@anywidget/react": "0.0.2",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
-	},
-	"devDependencies": {
-		"@types/react": "^18.2.21",
-		"@types/react-dom": "^18.2.7",
-		"typescript": "^5.2.2"
-	}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import * as React from "react";
-import { createRender, useModelState } from "@anywidget/react";
-import "./widget.css";
-
-export const render = createRender(() => {
-	const [value, setValue] = useModelState<number>("value");
-	return (
-		<button
-			className="ipyfoo-counter-button"
-			onClick={() => setValue(value + 1)}
-		>
-			count is {value}
-		</button>
-	);
-});
-"
-,
-    "path": "js/widget.tsx",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-  {
-    "content": 
-"{
-	"include": [
-		"js"
-	],
-	"compilerOptions": {
-		"target": "ES2020",
-		"module": "ESNext",
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		],
-		"skipLibCheck": true,
-		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react",
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
-	}
-}"
-,
-    "path": "tsconfig.json",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
-	},
-	"dependencies": {},
-	"devDependencies": {}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import "./widget.css";
-
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla-ts 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {},
-	"devDependencies": {
-		"@anywidget/types": "0.1.4",
-		"typescript": "^5.2.2"
-	}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import type { RenderContext } from "@anywidget/types";
-import "./widget.css";
-
-/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
-interface WidgetModel {
-	value: number;
-	/* Add your own */
-}
-
-export function render({ model, el }: RenderContext<WidgetModel>) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.ts",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-  {
-    "content": 
-"{
-	"include": [
-		"js"
-	],
-	"compilerOptions": {
-		"target": "ES2020",
-		"module": "ESNext",
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		],
-		"skipLibCheck": true,
-		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react",
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
-	}
-}"
-,
-    "path": "tsconfig.json",
-  },
-]
-`;
-
-exports[`create-anywidget template-vanilla-deno-jsdoc 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"{
-	"lock": false,
-	"compilerOptions": {
-		"checkJs": true,
-		"allowJs": true,
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		]
-	},
-	"fmt": {
-		"useTabs": true
-	},
-	"lint": {
-		"rules": {
-			"exclude": [
-				"prefer-const"
-			]
-		}
-	}
-}"
-,
-    "path": "deno.json",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import confetti from "https://esm.sh/canvas-confetti@1";
-
-/** @typedef {{ value: number }} Model */
-
-/** @type {import("npm:@anywidget/types").Render<Model>} */
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		confetti();
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget (Bun) template-vanilla 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.js --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]"
-	},
-	"dependencies": {},
-	"devDependencies": {}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import "./widget.css";
-
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-]
-`;
-
-exports[`create-anywidget (Bun) template-vanilla-ts 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-src/ipyfoo/static
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"{
-	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "bun build js/widget.ts --minify --format=esm --outdir=src/ipyfoo/static --asset-naming=[name].[ext]",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {},
-	"devDependencies": {
-		"@anywidget/types": "0.1.4",
-		"typescript": "^5.2.2"
-	}
-}"
-,
-    "path": "package.json",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-
-
-[tool.hatch.build]
-only-packages = true
-artifacts = ["src/ipyfoo/static/*"]
-
-[tool.hatch.build.hooks.jupyter-builder]
-build-function = "hatch_jupyter_builder.npm_builder"
-ensured-targets = ["src/ipyfoo/static/widget.js"]
-skip-if-exists = ["src/ipyfoo/static/widget.js"]
-dependencies = ["hatch-jupyter-builder>=0.5.0"]
-
-[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-npm = "npm"
-build_cmd = "build"
-path = "js"
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import type { RenderContext } from "@anywidget/types";
-import "./widget.css";
-
-/* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
-interface WidgetModel {
-	value: number;
-	/* Add your own */
-}
-
-export function render({ model, el }: RenderContext<WidgetModel>) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "js/widget.ts",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "js/widget.css",
-  },
-  {
-    "content": 
-"{
-	"include": [
-		"js"
-	],
-	"compilerOptions": {
-		"target": "ES2020",
-		"module": "ESNext",
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		],
-		"skipLibCheck": true,
-		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react",
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
-	}
-}"
-,
-    "path": "tsconfig.json",
-  },
-]
-`;
-
-exports[`create-anywidget (Bun) template-vanilla-deno-jsdoc 1`] = `
-[
-  {
-    "content": 
-"# ipyfoo
-
-\`\`\`sh
-pip install ipyfoo
-\`\`\`
-"
-,
-    "path": "README.md",
-  },
-  {
-    "content": 
-"[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "ipyfoo"
-version = "0.0.0"
-dependencies = ["anywidget"]
-
-[project.optional-dependencies]
-dev = ["watchfiles", "jupyterlab"]
-
-# automatically add the dev feature to the default env (e.g., hatch shell)
-[tool.hatch.envs.default]
-features = ["dev"]
-"
-,
-    "path": "pyproject.toml",
-  },
-  {
-    "content": 
-"{
-	"lock": false,
-	"compilerOptions": {
-		"checkJs": true,
-		"allowJs": true,
-		"lib": [
-			"ES2020",
-			"DOM",
-			"DOM.Iterable"
-		]
-	},
-	"fmt": {
-		"useTabs": true
-	},
-	"lint": {
-		"rules": {
-			"exclude": [
-				"prefer-const"
-			]
-		}
-	}
-}"
-,
-    "path": "deno.json",
-  },
-  {
-    "content": 
-"node_modules
-.venv
-dist
-
-# Python
-__pycache__
-.ipynb_checkpoints
-
-
-"
-,
-    "path": ".gitignore",
-  },
-  {
-    "content": 
-"import importlib.metadata
-import pathlib
-
-import anywidget
-import traitlets
-
-try:
-    __version__ = importlib.metadata.version("ipyfoo")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
-
-class Counter(anywidget.AnyWidget):
-    _esm = pathlib.Path(__file__).parent / "static" / "widget.js"
-    _css = pathlib.Path(__file__).parent / "static" / "widget.css"
-    value = traitlets.Int(0).tag(sync=True)
-"
-,
-    "path": "src/ipyfoo/__init__.py",
-  },
-  {
-    "content": 
-"import confetti from "https://esm.sh/canvas-confetti@1";
-
-/** @typedef {{ value: number }} Model */
-
-/** @type {import("npm:@anywidget/types").Render<Model>} */
-export function render({ model, el }) {
-	let btn = document.createElement("button");
-	btn.classList.add("ipyfoo-counter-button");
-	btn.innerHTML = \`count is ${model.get("value")}\`;
-	btn.addEventListener("click", () => {
-		model.set("value", model.get("value") + 1);
-		model.save_changes();
-	});
-	model.on("change:value", () => {
-		confetti();
-		btn.innerHTML = \`count is ${model.get("value")}\`;
-	});
-	el.appendChild(btn);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.js",
-  },
-  {
-    "content": 
-".ipyfoo-counter-button {
-	background: linear-gradient(
-		300deg,
-		#9933ff 33.26%,
-		#ff6666 46.51%,
-		#faca30 59.77%,
-		#00cd99 73.03%,
-		#00ccff 86.29%
-	);
-	border-radius: 10px;
-	border: 0;
-	color: white;
-	cursor: pointer;
-	font-family: "Roboto", sans-serif;
-	font-size: 2em;
-	margin: 10px;
-	padding: 10px 20px;
-	transition: transform 0.25s ease-in-out;
-}
-
-.ipyfoo-counter-button:hover {
-	transform: scale(1.05);
-}
-"
-,
-    "path": "src/ipyfoo/static/widget.css",
   },
 ]
 `;

--- a/packages/create-anywidget/__tests__/index.test.js
+++ b/packages/create-anywidget/__tests__/index.test.js
@@ -18,6 +18,7 @@ describe("create-anywidget", () => {
 
 describe("create-anywidget (Bun)", () => {
 	beforeAll(() => {
+		if ("Bun" in globalThis) return;
 		globalThis.Bun = true;
 	});
 

--- a/packages/create-anywidget/__tests__/index.test.js
+++ b/packages/create-anywidget/__tests__/index.test.js
@@ -1,7 +1,26 @@
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 import { gather_files } from "../create.js";
 
 describe("create-anywidget", () => {
+	test.each(
+		/** @type {const} */ ([
+			"template-vanilla",
+			"template-vanilla-ts",
+			"template-vanilla-deno-jsdoc",
+			"template-react",
+			"template-react-ts",
+		]),
+	)(`%s`, async (template) => {
+		const files = await gather_files(template, "ipyfoo");
+		expect(files).toMatchSnapshot();
+	});
+});
+
+describe("create-anywidget (Bun)", () => {
+	beforeAll(() => {
+		globalThis.Bun = true;
+	});
+
 	test.each(
 		/** @type {const} */ ([
 			"template-vanilla",

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -349,7 +349,7 @@ async function generate_package_json(template, { build_dir, typecheck }) {
 	/** @type {string[]} */
 	let dev_extra = [];
 	if ("Bun" in globalThis) {
-		scripts.build = `bun build ${template.entry_point} --outdir=${build_dir} --asset-naming=[name].[ext]`;
+		scripts.build = `bun build ${template.entry_point} --minify --format=esm --outdir=${build_dir} --asset-naming=[name].[ext]`;
 	} else {
 		scripts.build = `esbuild ${template.entry_point} --minify --format=esm --bundle --outdir=${build_dir}`;
 		dev_extra.push("esbuild");

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -349,9 +349,11 @@ async function generate_package_json(template, { build_dir, typecheck }) {
 	/** @type {string[]} */
 	let dev_extra = [];
 	if ("Bun" in globalThis) {
-		scripts.build = `bun build ${template.entry_point} --minify --format=esm --outdir=${build_dir} --asset-naming=[name].[ext]`;
+		scripts.build =
+			`bun build ${template.entry_point} --minify --format=esm --outdir=${build_dir} --asset-naming=[name].[ext]`;
 	} else {
-		scripts.build = `esbuild ${template.entry_point} --minify --format=esm --bundle --outdir=${build_dir}`;
+		scripts.build =
+			`esbuild ${template.entry_point} --minify --format=esm --bundle --outdir=${build_dir}`;
 		dev_extra.push("esbuild");
 	}
 

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -418,7 +418,7 @@ let deno_json = {
 /** @param {string} name */
 let widget_esm = (name) =>
 	`\
-import confetti from "https://esm.sh/canvas-confetti@1.6.0";
+import confetti from "https://esm.sh/canvas-confetti@1";
 
 /** @typedef {{ value: number }} Model */
 

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -186,7 +186,7 @@ let widget_react_ts = (name) =>
 	`\
 import * as React from "react";
 import { createRender, useModelState } from "@anywidget/react";
-import "./styles.css";
+import "./widget.css";
 
 export const render = createRender(() => {
 	const [value, setValue] = useModelState<number>("value");
@@ -206,7 +206,7 @@ let widget_react = (name) =>
 	`\
 import * as React from "react";
 import { createRender, useModelState } from "@anywidget/react";
-import "./styles.css";
+import "./widget.css";
 
 export const render = createRender(() => {
 	const [value, setValue] = useModelState("value");
@@ -224,7 +224,7 @@ export const render = createRender(() => {
 /** @param {string} name */
 let widget_vanilla = (name) =>
 	`\
-import "./styles.css";
+import "./widget.css";
 
 export function render({ model, el }) {
 	let btn = document.createElement("button");
@@ -245,7 +245,7 @@ export function render({ model, el }) {
 let widget_vanilla_ts = (name) =>
 	`\
 import type { RenderContext } from "@anywidget/types";
-import "./styles.css";
+import "./widget.css";
 
 /* Specifies attributes defined with traitlets in ../src/${name}/__init__.py */
 interface WidgetModel {
@@ -294,54 +294,80 @@ function get_tsconfig() {
 	});
 }
 
-const esbuild_templates = {
+/** @type {Record<string, { entry_point: string, files: { path: string, render: (name: string) => string }[], dependencies: string[], dev_dependencies: string[] }>} */
+const bundled_templates = {
 	"template-react": {
 		entry_point: "js/widget.jsx",
 		files: [
 			{ path: "js/widget.jsx", render: widget_react },
-			{ path: "js/styles.css", render: styles },
+			{ path: "js/widget.css", render: styles },
 		],
-		dependencies: ["@anywidget/react", "esbuild", "react", "react-dom"],
+		dependencies: ["@anywidget/react", "react", "react-dom"],
 		dev_dependencies: [],
 	},
 	"template-react-ts": {
 		entry_point: "js/widget.tsx",
 		files: [
 			{ path: "js/widget.tsx", render: widget_react_ts },
-			{ path: "js/styles.css", render: styles },
+			{ path: "js/widget.css", render: styles },
 			{ path: "tsconfig.json", render: get_tsconfig },
 		],
 		dependencies: ["@anywidget/react", "react", "react-dom"],
-		dev_dependencies: [
-			"@types/react",
-			"@types/react-dom",
-			"esbuild",
-			"typescript",
-		],
+		dev_dependencies: ["@types/react", "@types/react-dom", "typescript"],
 	},
 	"template-vanilla": {
 		entry_point: "js/widget.js",
 		files: [
 			{ path: "js/widget.js", render: widget_vanilla },
-			{ path: "js/styles.css", render: styles },
+			{ path: "js/widget.css", render: styles },
 		],
 		dependencies: [],
-		dev_dependencies: ["esbuild"],
+		dev_dependencies: [],
 	},
 	"template-vanilla-ts": {
 		entry_point: "js/widget.ts",
 		files: [
 			{ path: "js/widget.ts", render: widget_vanilla_ts },
-			{ path: "js/styles.css", render: styles },
+			{ path: "js/widget.css", render: styles },
 			{ path: "tsconfig.json", render: get_tsconfig },
 		],
 		dependencies: [],
-		dev_dependencies: ["@anywidget/types", "esbuild", "typescript"],
+		dev_dependencies: ["@anywidget/types", "typescript"],
 	},
 };
 
 /**
- * @param {typeof esbuild_templates[keyof esbuild_templates]} template
+ * @param {typeof bundled_templates[keyof bundled_templates]} template
+ * @param {{ build_dir: string, typecheck: boolean }} options
+ */
+async function generate_package_json(template, { build_dir, typecheck }) {
+	/** @type {Record<string, string>} */
+	let scripts = {
+		dev: "npm run build -- --sourcemap=inline --watch",
+	};
+
+	/** @type {string[]} */
+	let dev_extra = [];
+	if ("Bun" in globalThis) {
+		scripts.build = `bun build ${template.entry_point} --outdir=${build_dir} --asset-naming=[name].[ext]`;
+	} else {
+		scripts.build = `esbuild ${template.entry_point} --minify --format=esm --bundle --outdir=${build_dir}`;
+		dev_extra.push("esbuild");
+	}
+
+	let { dependencies, devDependencies } = await get_dependency_versions({
+		dependencies: template.dependencies,
+		dev_dependencies: [...template.dev_dependencies, ...dev_extra],
+	});
+
+	if (typecheck) {
+		scripts.typecheck = "tsc --noEmit";
+	}
+	return { scripts, dependencies, devDependencies };
+}
+
+/**
+ * @param {typeof bundled_templates[keyof bundled_templates]} template
  * @param {string} name
  */
 async function render_template(template, name) {
@@ -349,15 +375,10 @@ async function render_template(template, name) {
 	let tsconfig = template.files.find((file) =>
 		file.path.includes("tsconfig.json")
 	);
-	let package_json = {
-		scripts: {
-			dev: "npm run build -- --sourcemap=inline --watch",
-			build:
-				`esbuild --minify --format=esm --bundle --outdir=${build_dir} ${template.entry_point}`,
-			...(tsconfig ? { typecheck: `tsc --noEmit` } : {}),
-		},
-		...(await get_dependency_versions(template)),
-	};
+	let package_json = await generate_package_json(template, {
+		build_dir,
+		typecheck: !!tsconfig,
+	});
 	let files = template.files.map((file) => ({
 		path: file.path,
 		content: file.render(name),
@@ -429,17 +450,17 @@ export async function gather_files(type, name) {
 			{ path: `.gitignore`, content: gitignore() },
 			{ path: `src/${name}/__init__.py`, content: __init__(name) },
 			{ path: `src/${name}/static/widget.js`, content: widget_esm(name) },
-			{ path: `src/${name}/static/styles.css`, content: styles(name) },
+			{ path: `src/${name}/static/widget.css`, content: styles(name) },
 		];
 	}
-	if (type in esbuild_templates) {
-		return render_template(esbuild_templates[type], name);
+	if (type in bundled_templates) {
+		return render_template(bundled_templates[type], name);
 	}
 	throw new Error(`Unknown template type: ${type}`);
 }
 
 /** @typedef {{ content: string, path: string }} File */
-/** @typedef {keyof esbuild_templates | "template-vanilla-deno-jsdoc"} TemplateType */
+/** @typedef {keyof bundled_templates | "template-vanilla-deno-jsdoc"} TemplateType */
 
 /**
  * @param {string} target

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -15,7 +15,6 @@ async function read_json(path) {
 	return fs.readFile(path, "utf-8").then(JSON.parse);
 }
 
-
 /**
  * pnpm will help us keep package versions in sync over time, along with dependabot,
  * so we lookup the version from `package.json` to use for those in our templates.

--- a/packages/create-anywidget/index.js
+++ b/packages/create-anywidget/index.js
@@ -27,12 +27,22 @@ let p = new Proxy(_p, {
 	},
 });
 
+// https://github.com/withastro/astro/blob/fca6892f8d6a30ceb1e04213be2414dd4cb4d389/packages/create-astro/src/actions/context.ts#L110-L115
+function detect_package_manager() {
+	if ("Bun" in globalThis) return "bun";
+	if (!process.env.npm_config_user_agent) return;
+	const specifier = process.env.npm_config_user_agent.split(" ")[0];
+	const name = specifier.substring(0, specifier.lastIndexOf("/"));
+	return name === "npminstall" ? "cnpm" : name;
+}
+
 let pkg = await fs.promises
 	.readFile(new URL("package.json", import.meta.url), "utf-8")
 	.then(JSON.parse);
 
 let cwd = process.argv[2] || ".";
 
+console.clear();
 console.log(`
 ${grey(`create-anywidget version ${pkg.version}`)}
 `);
@@ -121,9 +131,12 @@ if (p.isCancel(template)) {
 	process.exit(1);
 }
 
+let pkg_manager = detect_package_manager() ?? "npm";
+
 let writtenPaths = await create(cwd, {
 	name: path.basename(path.resolve(cwd)),
 	template: /** @type {import("./create.js").TemplateType} */ (template),
+	pkg_manager,
 }).catch((err) => {
 	console.error("Error writing files:", err);
 	process.exit(1);
@@ -152,9 +165,8 @@ console.log(
 );
 
 if (template !== "template-vanilla-deno-jsdoc") {
-	console.log(`  ${i++}: ${bold(cyan("npm install"))} (or pnpm install, etc)`);
-
-	console.log(`  ${i++}: ${bold(cyan("npm run dev"))}`);
+	console.log(`  ${i++}: ${bold(cyan(`${pkg_manager} install`))}`);
+	console.log(`  ${i++}: ${bold(cyan(`${pkg_manager} run dev`))}`);
 	console.log(`\nTo close the dev server, hit ${bold(cyan("Ctrl-C"))}`);
 }
 


### PR DESCRIPTION
Bun is a replacement for Node.js and comes with a built-in package manager and bundler (and test runner!). I think it very well suited as a companion for anywidget projects. I'd like the templates to fully support bun.

This PR detects if the project is running in Node.js or bun by looking at the `globalThis.Bun` and then generates the `build` script in the package.json based on the the environtment:

- Node.js - `esbuild --bundle`
- Bun - `bun bundle`

The difference is that this eliminates a dependency in those templates in favor of the "bun" version.

TODO: I need to figure out how/if the hatchling jupyter builder supports bun.
