### PR TITLE
Add .venv to gitignore

### DIFF
--- a/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
@@ -13,6 +13,7 @@ pip install ipyfoo
   },
   {
     "content": "node_modules
+.venv
 dist
 
 # Python
@@ -58,6 +59,7 @@ features = [\\"dev\\"]
 
 
 [tool.hatch.build]
+only-packages = true
 artifacts = [\\"src/ipyfoo/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
@@ -155,6 +157,7 @@ pip install ipyfoo
   },
   {
     "content": "node_modules
+.venv
 dist
 
 # Python
@@ -205,6 +208,7 @@ features = [\\"dev\\"]
 
 
 [tool.hatch.build]
+only-packages = true
 artifacts = [\\"src/ipyfoo/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
@@ -330,6 +334,7 @@ pip install ipyfoo
   },
   {
     "content": "node_modules
+.venv
 dist
 
 # Python
@@ -372,6 +377,7 @@ features = [\\"dev\\"]
 
 
 [tool.hatch.build]
+only-packages = true
 artifacts = [\\"src/ipyfoo/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]
@@ -513,6 +519,7 @@ features = [\\"dev\\"]
   },
   {
     "content": "node_modules
+.venv
 dist
 
 # Python
@@ -609,6 +616,7 @@ pip install ipyfoo
   },
   {
     "content": "node_modules
+.venv
 dist
 
 # Python
@@ -654,6 +662,7 @@ features = [\\"dev\\"]
 
 
 [tool.hatch.build]
+only-packages = true
 artifacts = [\\"src/ipyfoo/static/*\\"]
 
 [tool.hatch.build.hooks.jupyter-builder]

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -93,6 +93,7 @@ let pyproject_toml_with_hatch_jupyter_builder = (name) =>
 	pyproject_toml(name) +
 	`\n
 [tool.hatch.build]
+only-packages = true
 artifacts = ["src/${name}/static/*"]
 
 [tool.hatch.build.hooks.jupyter-builder]

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -132,6 +132,7 @@ class Counter(anywidget.AnyWidget):
 let gitignore = (extras = []) =>
 	`\
 node_modules
+.venv
 dist
 
 # Python


### PR DESCRIPTION
For convenience.

I always include .venv in my global gitignore. However, I discovered that "hatch build" requires .venv to also be in the project's gitignore. If not, .venv will be uploaded to PyPI. I experienced this issue firsthand; it took a long time to upload, and it was a challenge to identify the reason for the large package size!




