### PR TITLE
feat(deno): add experimenal deno mod

### DIFF
--- a/packages/anywidget/mod.ts
+++ b/packages/anywidget/mod.ts
@@ -1,19 +1,5 @@
 import mitt, { type Emitter } from "npm:mitt@3";
 
-declare global {
-	namespace Deno {
-		namespace jupyter {
-			function broadcast(
-				method: string,
-				content: Record<string, unknown>,
-				extra?: {
-					metadata?: Record<string, unknown>;
-				},
-			): Promise<void>;
-		}
-	}
-}
-
 class Comm {
 	id: string;
 	#protocol_version_major: number;

--- a/packages/anywidget/mod.ts
+++ b/packages/anywidget/mod.ts
@@ -1,0 +1,137 @@
+import mitt, { type Emitter } from "npm:mitt@3";
+
+declare global {
+	namespace Deno {
+		namespace jupyter {
+			function broadcast(
+				method: string,
+				content: Record<string, unknown>,
+				extra?: {
+					metadata?: Record<string, unknown>;
+				},
+			): Promise<void>;
+		}
+	}
+}
+
+class Comm {
+	id: string;
+	#protocol_version_major: number;
+	#protocol_version_minor: number;
+	#anywidget_version: string;
+
+	constructor() {
+		this.id = crypto.randomUUID();
+		this.#protocol_version_major = 2;
+		this.#protocol_version_minor = 1;
+		this.#anywidget_version = "0.6.5";
+	}
+
+	async init() {
+		await Deno.jupyter.broadcast(
+			"comm_open",
+			{
+				"comm_id": this.id,
+				"target_name": "jupyter.widget",
+				"data": {
+					"state": {
+						"_model_module": "anywidget",
+						"_model_name": "AnyModel",
+						"_model_module_version": this.#anywidget_version,
+						"_view_module": "anywidget",
+						"_view_name": "AnyView",
+						"_view_module_version": this.#anywidget_version,
+						"_view_count": null,
+					},
+				},
+			},
+			{
+				"metadata": {
+					"version":
+						`${this.#protocol_version_major}.${this.#protocol_version_minor}.0`,
+				},
+			},
+		);
+	}
+
+	async send_state(state: object) {
+		await Deno.jupyter.broadcast("comm_msg", {
+			"comm_id": this.id,
+			"data": { "method": "update", "state": state },
+		});
+	}
+
+	mimebundle() {
+		return {
+			"application/vnd.jupyter.widget-view+json": {
+				"version_major": this.#protocol_version_major,
+				"version_minor": this.#protocol_version_minor,
+				"model_id": this.id,
+			},
+		};
+	}
+}
+
+type ChangeEvents<State> = {
+	[K in (string & keyof State) as `change:${K}`]: State[K];
+};
+
+class Model<State> {
+	_state: State;
+	_emitter: Emitter<ChangeEvents<State>>;
+
+	constructor(state: State) {
+		this._state = state;
+		this._emitter = mitt<ChangeEvents<State>>();
+	}
+	get<K extends keyof State>(key: K): State[K] {
+		return this._state[key];
+	}
+	set<K extends keyof State>(key: K, value: State[K]): void {
+		// @ts-expect-error can't convince TS that K is a key of State
+		this._emitter.emit(`change:${key}`, value);
+		this._state[key] = value;
+	}
+	on<Event extends keyof ChangeEvents<State>>(
+		name: Event,
+		callback: (data: ChangeEvents<State>[Event]) => void,
+	): void {
+		this._emitter.on(name, callback);
+	}
+}
+
+type FrontEndModel<State> = Model<State> & {
+	save_changes(): void;
+};
+
+export async function widget<State>({ state, render }: {
+	state: State;
+	render: (
+		context: {
+			model: FrontEndModel<State>;
+			el: HTMLElement;
+		},
+	) => unknown;
+}) {
+	let model = new Model(state);
+	let comm = new Comm();
+	await comm.init();
+	// TODO: more robust serialization of render function (with context?)
+	await comm.send_state({
+		...state,
+		_esm: "export const render = " + render.toString(),
+	});
+	for (let key in state) {
+		model.on(`change:${key}`, (data) => {
+			comm.send_state({ [key]: data });
+		});
+	}
+	return new Proxy(model, {
+		get(target, prop, receiver) {
+			if (prop === Symbol.for("Jupyter.display")) {
+				return comm.mimebundle.bind(comm);
+			}
+			return Reflect.get(target, prop, receiver);
+		},
+	});
+}


### PR DESCRIPTION
Adds a `mod.ts` for minimal boilerplate for using anywidget frontend from Deno jupyter kernel.

```ts
import { widget } from "https://github.com/manzt/anywidget/mod.ts";

let model = await widget({
    // shared model between frontend and backend
    state: { value: 0 },
    // front-end render function
    render: ({ model, el }) => {
        let h1 = Object.assign(document.createElement("h1"), {
            innerText: "Value is " + model.get("value"),
        });
        model.on("change:value", () => {
            h1.innerText = "Value is " + model.get("value");
        });
        el.appendChild(h1);
    }
});

model
```

```ts
for (let i = 1; i <= 10; i++) {
    model.set("value", i);
    await new Promise(resolve => setTimeout(resolve, 500));
}
```
