### PR TITLE
accept imports in deno anywidget

### DIFF
--- a/packages/anywidget/mod.ts
+++ b/packages/anywidget/mod.ts
@@ -90,8 +90,9 @@ type FrontEndModel<State> = Model<State> & {
 	save_changes(): void;
 };
 
-export async function widget<State>({ state, render }: {
+export async function widget<State>({ state, render, imports }: {
 	state: State;
+	imports: string;
 	render: (
 		context: {
 			model: FrontEndModel<State>;
@@ -103,9 +104,10 @@ export async function widget<State>({ state, render }: {
 	let comm = new Comm();
 	await comm.init();
 	// TODO: more robust serialization of render function (with context?)
+	const _esm = `${imports}\nexport const render = ${render.toString()}`;
 	await comm.send_state({
 		...state,
-		_esm: "export const render = " + render.toString(),
+		_esm,
 	});
 	for (let key in state) {
 		model.on(`change:${key}`, (data) => {


### PR DESCRIPTION
This is a rough way to include imports, which could be a general preamble instead.

```typescript
import { widget } from "./mod.ts";

let model = await widget({
    // shared model between frontend and backend
    state: { data: [4, 8, 15, 16, 23, 42] },
    imports: `
import * as d3 from "https://esm.sh/d3@7";
`,
    // front-end render function 
    render: ({ model, el }) => {
        const width = 500;
        const svg = d3.select(el)
          .append("svg")
          .attr("width", width)

        const x = d3.scaleLinear()
          .range([0, width]);

        const updateChart = (data) => {
            // Update scale domain based on new data
            x.domain([0, d3.max(data)!]);

            const bars = svg.selectAll("rect")
                .data(data);

            // Update existing bars
            bars
                .attr("width", x)
                .attr("y", (d, i) => i * 25)
                .attr("height", 20);

            // Add new bars
            bars.enter().append("rect")
                .attr("x", 0)
                .attr("y", (d, i) => i * 25)
                .attr("width", x)
                .attr("height", 20)
                .attr("fill", "#69b3a2");

            // Remove extra bars
            bars.exit().remove();
        };

        // Initial render
        updateChart(model.get('data'));

        model.on("change:data", () => {
            updateChart(model.get('data'));
        });
    }
});

model
```

![Export-1696124360731](https://github.com/manzt/anywidget/assets/836375/f2e00c32-df50-4dc9-915b-c08cc05a92a6)

On a side note, my editor defaults to using `deno fmt`. Could we use the builtin deno formatting for the deno project portion?