### PR TITLE
feat(experimental): Support getting partial state

### DIFF
--- a/.changeset/serious-panthers-battle.md
+++ b/.changeset/serious-panthers-battle.md
@@ -2,4 +2,32 @@
 "anywidget": patch
 ---
 
-feat(experimental): Allow picking fields when serializing state
+feat(experimental)!: Require `include` in `_get_anywidget_state` signature
+
+Allows implementors to avoid re-serializing fields which aren't needed to send to the front end.
+This is a BREAKING change because it requires implementors of `_get_anywidget_state` to
+account for `include` in the function signature.
+
+```python
+from dataclasses import dataclass, asdict
+from io import BytesIO
+
+import polars as pl
+import psygnal
+
+@psygnal.evented
+@dataclass
+class Foo:
+  value: int
+  df: pl.DataFrame
+
+  def _get_anywidget_state(self, include: set[str] | None):
+    data = asdict(self)
+    if include and "df" in include:
+      with BytesIO() as f:
+        self.df.write_ipc(f)
+        data["df"] = f.getvalue()
+    else:
+      del data["df"] # don't serialize df to bytes
+    return data
+```

--- a/.changeset/serious-panthers-battle.md
+++ b/.changeset/serious-panthers-battle.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+feat(experimental): Allow picking fields when serializing state

--- a/.changeset/serious-panthers-battle.md
+++ b/.changeset/serious-panthers-battle.md
@@ -4,9 +4,9 @@
 
 feat(experimental)!: Require `include` in `_get_anywidget_state` signature
 
-Allows implementors to avoid re-serializing fields which aren't needed to send to the front end.
-This is a BREAKING change because it requires implementors of `_get_anywidget_state` to
-account for `include` in the function signature.
+Allows implementors to avoid re-serializing fields which aren't needed to send
+to the front end. This is a BREAKING change because it requires implementors of
+`_get_anywidget_state` to account for `include` in the function signature.
 
 ```python
 from dataclasses import dataclass, asdict

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -18,12 +18,13 @@
 from __future__ import annotations
 
 import contextlib
+import inspect
 import json
 import sys
 import warnings
 import weakref
 from dataclasses import asdict, is_dataclass
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Protocol, Sequence, cast, overload
 
 from ._file_contents import FileContents
 from ._util import (
@@ -328,9 +329,13 @@ class ReprMimeBundle:
         if obj is None:
             return  # pragma: no cover  ... the python object has been deleted
 
-        state = {**self._get_state(obj), **self._extra_state}
         if include is not None:
             include = {include} if isinstance(include, str) else set(include)
+
+        state = {**self._get_state(obj, include=include), **self._extra_state}
+        if include is not None:
+            # ensure that we only send the keys that were requested
+            # incase the state getter returned extra keys
             state = {k: v for k, v in state.items() if k in include}
 
         if not state:
@@ -454,7 +459,26 @@ def _anywidget_id(obj: object) -> str:
     return f"{type(obj).__module__}.{type(obj).__name__}"
 
 
-def determine_state_getter(obj: object) -> Callable[[Any], Serializable]:
+def _wrap_getter(get_state: _GetState) -> _GetPickableState:
+    """Wrap a function to return a Serializable object."""
+
+    def wrapper(obj: Any, include: set[str] | None) -> Serializable:
+        return get_state(obj)
+
+    return wrapper
+
+
+class _GetState(Protocol):
+    def __call__(self, obj: Any) -> Serializable:
+        ...
+
+class _GetPickableState(Protocol):
+    def __call__(self, obj: Any, include: set[str] | None) -> Serializable:
+        ...
+
+def determine_state_getter(
+    obj: object,
+) -> _GetPickableState:
     """Autodetect how `obj` can be serialized to a dict.
 
     This looks for various special methods and patterns on the object (e.g. dataclass,
@@ -473,15 +497,18 @@ def determine_state_getter(obj: object) -> Callable[[Any], Serializable]:
     if hasattr(type(obj), _STATE_GETTER_NAME):
         # note that we return the *unbound* method on the class here, so that it can be
         # called with the object as the first argument
-        return getattr(type(obj), _STATE_GETTER_NAME)  # type: ignore [no-any-return]
+        get_state = getattr(type(obj), _STATE_GETTER_NAME)
+        if "include" in inspect.signature(get_state).parameters.keys():
+            return get_state # type: ignore [no-any-return]
+        return _wrap_getter(get_state)
 
     if is_dataclass(obj):
         # caveat: if the dict is not JSON serializeable... you still need to
         # provide an API for the user to customize serialization
-        return asdict
+        return _wrap_getter(asdict)
 
     if _is_traitlets_object(obj):
-        return _get_traitlets_state
+        return _wrap_getter(_get_traitlets_state)
 
     if _is_pydantic_model(obj):
         if hasattr(obj, "model_dump"):
@@ -489,7 +516,7 @@ def determine_state_getter(obj: object) -> Callable[[Any], Serializable]:
         return _get_pydantic_state_v1
 
     if _is_msgspec_struct(obj):
-        return _get_msgspec_state
+        return _wrap_getter(_get_msgspec_state)
 
     # pickle protocol ... probably not type-safe enough for our purposes
     # https://docs.python.org/3/library/pickle.html#object.__getstate__
@@ -596,7 +623,7 @@ _TRAITLETS_SYNC_FLAG = "sync"
 # state isn't being synced without opting in.
 
 
-def _get_traitlets_state(obj: traitlets.HasTraits) -> Serializable:
+def _get_traitlets_state(obj: traitlets.HasTraits, **kwargs) -> Serializable:
     """Get the state of a traitlets.HasTraits instance."""
     kwargs = {_TRAITLETS_SYNC_FLAG: True}
     return obj.trait_values(**kwargs)  # type: ignore [no-untyped-call]
@@ -640,19 +667,23 @@ def _is_pydantic_model(obj: Any) -> TypeGuard[pydantic.BaseModel]:
     return isinstance(obj, pydantic.BaseModel) if pydantic is not None else False
 
 
-def _get_pydantic_state_v1(obj: pydantic.BaseModel) -> Serializable:
+def _get_pydantic_state_v1(
+    obj: pydantic.BaseModel, include: set[str] | None
+) -> Serializable:
     """Get the state of a pydantic BaseModel instance.
 
     To take advantage of pydantic's support for custom encoders (with json_encoders)
     we call obj.json() here, and then cast back to a dict (which is what
     the comm expects).
     """
-    return json.loads(obj.json())
+    return json.loads(obj.json(include=include))
 
 
-def _get_pydantic_state_v2(obj: pydantic.BaseModel) -> Serializable:
+def _get_pydantic_state_v2(
+    obj: pydantic.BaseModel, include: set[str] | None
+) -> Serializable:
     """Get the state of a pydantic (v2) BaseModel instance."""
-    return obj.model_dump(mode="json")
+    return obj.model_dump(mode="json", include=include)
 
 
 # ------------- msgspec support --------------
@@ -664,7 +695,7 @@ def _is_msgspec_struct(obj: Any) -> TypeGuard[msgspec.Struct]:
     return isinstance(obj, msgspec.Struct) if msgspec is not None else False
 
 
-def _get_msgspec_state(obj: msgspec.Struct) -> dict:
+def _get_msgspec_state(obj: msgspec.Struct, **kwargs) -> dict:
     """Get the state of a msgspec.Struct instance."""
     import msgspec
 

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -623,7 +623,7 @@ _TRAITLETS_SYNC_FLAG = "sync"
 # state isn't being synced without opting in.
 
 
-def _get_traitlets_state(obj: traitlets.HasTraits, **kwargs) -> Serializable:
+def _get_traitlets_state(obj: traitlets.HasTraits) -> Serializable:
     """Get the state of a traitlets.HasTraits instance."""
     kwargs = {_TRAITLETS_SYNC_FLAG: True}
     return obj.trait_values(**kwargs)  # type: ignore [no-untyped-call]
@@ -695,7 +695,7 @@ def _is_msgspec_struct(obj: Any) -> TypeGuard[msgspec.Struct]:
     return isinstance(obj, msgspec.Struct) if msgspec is not None else False
 
 
-def _get_msgspec_state(obj: msgspec.Struct, **kwargs) -> dict:
+def _get_msgspec_state(obj: msgspec.Struct) -> dict:
     """Get the state of a msgspec.Struct instance."""
     import msgspec
 

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -28,7 +28,6 @@ from typing import (
     Any,
     Callable,
     Iterable,
-    Protocol,
     Sequence,
     cast,
     overload,
@@ -53,9 +52,13 @@ if TYPE_CHECKING:  # pragma: no cover
     import psygnal
     import pydantic
     import traitlets
-    from typing_extensions import TypeAlias, TypeGuard
+    from typing_extensions import Protocol, TypeAlias, TypeGuard
 
     from ._protocols import CommMessage
+
+    class _GetState(Protocol):
+        def __call__(self, obj: Any, include: set[str] | None) -> dict:
+            ...
 
     # catch all for types that can be serialized ... too hard to actually type
     Serializable: TypeAlias = Any
@@ -467,14 +470,7 @@ def _anywidget_id(obj: object) -> str:
     return f"{type(obj).__module__}.{type(obj).__name__}"
 
 
-class _GetState(Protocol):
-    def __call__(self, obj: Any, include: set[str] | None) -> Serializable:
-        ...
-
-
-def determine_state_getter(
-    obj: object,
-) -> _GetState:
+def determine_state_getter(obj: object) -> _GetState:
     """Autodetect how `obj` can be serialized to a dict.
 
     This looks for various special methods and patterns on the object (e.g. dataclass,

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import time
 import weakref

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -73,7 +73,7 @@ def test_descriptor(mock_comm: MagicMock) -> None:
         _repr_mimebundle_ = MimeBundleDescriptor(autodetect_observer=False)
         value: int = VAL
 
-        def _get_anywidget_state(self):
+        def _get_anywidget_state(self, include: set[str] | None):
             return {"value": self.value}
 
         def __repr__(self) -> str:
@@ -110,7 +110,7 @@ def test_state_setter(mock_comm: MagicMock):
     class Foo:
         _repr_mimebundle_ = MimeBundleDescriptor(autodetect_observer=False)
 
-        def _get_anywidget_state(self):
+        def _get_anywidget_state(self, include: set[str] | None):
             return {}
 
         def _set_anywidget_state(self, state):
@@ -130,7 +130,7 @@ def test_comm_cleanup():
     class Foo:
         _repr_mimebundle_ = MimeBundleDescriptor(autodetect_observer=False)
 
-        def _get_anywidget_state(self):
+        def _get_anywidget_state(self, include: set[str] | None):
             return {}
 
     foo = Foo()
@@ -154,7 +154,7 @@ def test_detect_observer():
     class Foo:
         _repr_mimebundle_ = MimeBundleDescriptor()
 
-        def _get_anywidget_state(self):
+        def _get_anywidget_state(self, include: set[str] | None):
             return {}
 
     with pytest.warns(UserWarning, match="Could not find a notifier"):
@@ -170,7 +170,7 @@ def test_descriptor_on_slots() -> None:
         _repr_mimebundle_ = MimeBundleDescriptor()
         value: int = 1
 
-        def _get_anywidget_state(self):
+        def _get_anywidget_state(self, include: set[str] | None):
             return {"value": self.value}
 
     with pytest.warns(UserWarning, match=".*is not weakrefable"):
@@ -300,7 +300,7 @@ def test_infer_file_contents(mock_comm: MagicMock, tmp_path: pathlib.Path) -> No
         _repr_mimebundle_ = MimeBundleDescriptor(_esm=esm, autodetect_observer=False)
         value: int = 1
 
-        def _get_anywidget_state(self):
+        def _get_anywidget_state(self, include: set[str] | None):
             return {"value": self.value}
 
     file_contents = Foo._repr_mimebundle_._extra_state["_esm"]
@@ -348,7 +348,7 @@ def test_explicit_file_contents(tmp_path: pathlib.Path) -> None:
         _repr_mimebundle_ = MimeBundleDescriptor(bar=bar, autodetect_observer=False)
         value: int = 1
 
-        def _get_anywidget_state(self):
+        def _get_anywidget_state(self, include: set[str] | None):
             return {"value": self.value}
 
     file_contents = Foo._repr_mimebundle_._extra_state["bar"]

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -123,6 +123,32 @@ def test_state_setter(mock_comm: MagicMock):
     mock.assert_called_once_with(state)
 
 
+def test_state_setter_binary(mock_comm: MagicMock):
+    """Test that `_set_anywidget_state` is used when present."""
+    mock = MagicMock()
+
+    class Foo:
+        _repr_mimebundle_ = MimeBundleDescriptor(autodetect_observer=False)
+
+        def _get_anywidget_state(self, include: Union[Set[str], None]):
+            return {}
+
+        def _set_anywidget_state(self, state):
+            mock(state)
+
+    foo = Foo()
+    foo._repr_mimebundle_
+    mock_comm.handle_msg(
+        {
+            "content": {
+                "data": {"method": "update", "state": {}, "buffer_paths": [["value"]]}
+            },
+            "buffers": [b"hello"],
+        }
+    )
+    mock.assert_called_once_with({"value": b"hello"})
+
+
 def test_comm_cleanup():
     """Test that the comm is cleaned up when the object is deleted."""
     assert not _COMMS

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -48,7 +48,7 @@ def mock_comm():
     assert not _COMMS
 
 
-def _send_value(comm: "Comm", value: int) -> int:
+def _send_value(comm: Comm, value: int) -> int:
     # test that the object responds to incoming messages
     comm.handle_msg(
         {"content": {"data": {"method": "update", "state": {"value": value}}}}
@@ -56,7 +56,7 @@ def _send_value(comm: "Comm", value: int) -> int:
     return value
 
 
-def _assert_sends_update(wdg: "AnywidgetProtocol", comm: MagicMock, expect: int):
+def _assert_sends_update(wdg: AnywidgetProtocol, comm: MagicMock, expect: int):
     # test that the comm sends update messages
     wdg._repr_mimebundle_.send_state({"value"})
     comm.send.assert_called_with(


### PR DESCRIPTION
This PR introduces an required `include` parameter to `_get_anywidget_state` for selective field serialization. This can help optimize performance by avoiding serializing fields that aren't emitted in events to the front end.

This is a BREAKING change because it requires implementors of `_get_anywidget_state` to
account for `include` in the function signature.

```python
from dataclasses import dataclass, asdict
from io import BytesIO

import polars as pl
import psygnal

@psygnal.evented
@dataclass
class Foo:
  value: int
  df: pl.DataFrame

  def _get_anywidget_state(self, include: set[str] | None):
    data = asdict(self)
    if include and "df" in include:
      with BytesIO() as f:
        self.df.write_ipc(f)
        data["df"] = f.getvalue()
    else:
      del data["df"] # don't serialize df to bytes
    return data
```

Thoughts, @kylebarron?