### PR TITLE
feat(deno): discover installed anywidget version

### DIFF
--- a/.changeset/hip-pianos-impress.md
+++ b/.changeset/hip-pianos-impress.md
@@ -1,0 +1,5 @@
+---
+"@anywidget/deno": patch
+---
+
+feat: Try to discover installed anywidget version


### PR DESCRIPTION
Tries to discover the widget version from `share/jupyter/labextension/anywidget/package.json` which is added to the `VIRTUAL_ENV` after running `pip install anywidget`.