### PR TITLE
Fix Deno example README.md

### DIFF
--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -67,7 +67,7 @@ model;
 `In[2]:`
 
 ```typescript
-let dict = await Deno.readTextFile("/usr/share/dict/words").split("\n");
+let dict = await Deno.readTextFile("/usr/share/dict/words");
 for (let word of dict.split("\n")) {
 	model.set("letters", word);
 	await new Promise((resolve) => setTimeout(resolve, 500));


### PR DESCRIPTION
The string split happens later in the example and the promise has to be awaited first.