### PR TITLE
feat(deno): Add (un)install scripts for front end code

### DIFF
--- a/.changeset/metal-yaks-tickle.md
+++ b/.changeset/metal-yaks-tickle.md
@@ -5,5 +5,5 @@
 feat: Add Install/Uninstall scripts for widget front end
 
 ```sh
-deno run -A https://deno.land/anywidget/install.ts
+deno run -A https://deno.land/x/anywidget/install.ts
 ```

--- a/.changeset/metal-yaks-tickle.md
+++ b/.changeset/metal-yaks-tickle.md
@@ -1,0 +1,9 @@
+---
+"@anywidget/deno": patch
+---
+
+feat: Add Install/Uninstall scripts for widget front end
+
+```sh
+deno run -A https://deno.land/anywidget/install.ts
+```

--- a/.changeset/serious-panthers-battle.md
+++ b/.changeset/serious-panthers-battle.md
@@ -5,8 +5,8 @@
 feat(experimental)!: Require `include` in `_get_anywidget_state` signature
 
 Allows implementors to avoid re-serializing fields which aren't needed to send
-to the front end. This is a **BREAKING** change because it requires implementors of
-`_get_anywidget_state` to account for `include` in the function signature.
+to the front end. This is a **BREAKING** change because it requires implementors
+of `_get_anywidget_state` to account for `include` in the function signature.
 
 ```python
 from dataclasses import dataclass, asdict

--- a/packages/deno/install.ts
+++ b/packages/deno/install.ts
@@ -58,4 +58,6 @@ for (let [name, reader] of Object.entries(archive.entries)) {
 console.log(`✅ Installed anywidget ${version} in ${out_dir}`);
 console.log(path.join(out_dir, "share/jupyter/labextensions/anywidget/"));
 console.log(path.join(out_dir, "share/jupyter/nbextensions/anywidget/"));
-console.log(path.join(out_dir, "etc/jupyter/nbconfig/notebook.d/anywidget.json"));
+console.log(
+	path.join(out_dir, "etc/jupyter/nbconfig/notebook.d/anywidget.json"),
+);

--- a/packages/deno/install.ts
+++ b/packages/deno/install.ts
@@ -49,7 +49,7 @@ async function fetch_wheel(
 function extract_data_files(
 	zip: unzipit.ZipInfo,
 ): Promise<[string, Uint8Array][]> {
-	let data_prefix = /^.*\.data\/data\/share\/jupyter\/labextensions\//;
+	let data_prefix = /^.*\.data\/data\/share\/jupyter\//;
 	return Promise.all(
 		Object
 			.entries(zip.entries)

--- a/packages/deno/install.ts
+++ b/packages/deno/install.ts
@@ -1,0 +1,61 @@
+import * as path from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as fs from "https://deno.land/std@0.203.0/fs/mod.ts";
+import * as flags from "https://deno.land/std@0.203.0/flags/mod.ts";
+import * as unzipit from "npm:unzipit@1.4.3";
+
+type PkgInfoEntry = {
+	packagetype: string;
+	url: string;
+};
+
+type PkgInfo = {
+	info: { version: string };
+	releases: Record<string, PkgInfoEntry[]>;
+	urls: PkgInfoEntry[];
+};
+
+let { version, venv } = flags.parse(Deno.args, {
+	string: ["version", "venv"],
+});
+let pkg_info: PkgInfo = await fetch("https://pypi.org/pypi/anywidget/json")
+	.then((r) => r.json());
+
+let info: PkgInfoEntry[];
+if (version === undefined) {
+	version = pkg_info.info.version;
+	info = pkg_info.urls;
+} else {
+	info = pkg_info.releases[version];
+}
+
+if (!info) {
+	console.log("No entries found for version " + version);
+	Deno.exit(1);
+}
+
+let wheel = info.find((e) => e.packagetype == "bdist_wheel");
+
+if (!wheel) {
+	console.log("No wheel found for version " + version);
+	Deno.exit(1);
+}
+
+let archive = await unzipit.unzip(wheel.url);
+let prefix_regex = new RegExp("^anywidget-" + version + ".data/data/");
+let out_dir = path.resolve(venv ?? Deno.env.get("VIRTUAL_ENV") ?? "/usr/local");
+
+let files = [];
+for (let [name, reader] of Object.entries(archive.entries)) {
+	if (!prefix_regex.test(name)) continue;
+	let file_path = path.resolve(out_dir, name.replace(prefix_regex, ""));
+	await fs.ensureFile(file_path);
+	await Deno.writeFile(
+		file_path,
+		new Uint8Array(await reader.arrayBuffer()),
+	);
+	files.push(file_path);
+}
+console.log(`✅ Installed anywidget ${version} in ${out_dir}`);
+console.log(path.join(out_dir, "share/jupyter/labextensions/anywidget/"));
+console.log(path.join(out_dir, "share/jupyter/nbextensions/anywidget/"));
+console.log(path.join(out_dir, "etc/jupyter/nbconfig/notebook.d/anywidget.json"));

--- a/packages/deno/install.ts
+++ b/packages/deno/install.ts
@@ -3,7 +3,11 @@ import * as fs from "https://deno.land/std@0.203.0/fs/mod.ts";
 import * as flags from "https://deno.land/std@0.203.0/flags/mod.ts";
 import * as unzipit from "npm:unzipit@1.4";
 import * as z from "npm:zod@3.9";
-import { find_data_dir, user_data_dir, system_data_dirs } from "./jupyter_paths.ts";
+import {
+	find_data_dir,
+	system_data_dirs,
+	user_data_dir,
+} from "./jupyter_paths.ts";
 
 let ReleaseSchema = z.object({
 	packagetype: z.string(),
@@ -94,8 +98,7 @@ let out_dir = await find_data_dir();
 	console.log(`✅ Installed anywidget ${version} in ${out_dir}`);
 }
 
-
-if (!(await has_jupyter_widgets())){
+if (!(await has_jupyter_widgets())) {
 	/**
 	 * NB: The anywidget front-end code relies on @jupyter-widgets/base,
 	 * which is supplied by the _python_ `jupyterlab_widgets` package.

--- a/packages/deno/install.ts
+++ b/packages/deno/install.ts
@@ -1,63 +1,81 @@
 import * as path from "https://deno.land/std@0.203.0/path/mod.ts";
 import * as fs from "https://deno.land/std@0.203.0/fs/mod.ts";
 import * as flags from "https://deno.land/std@0.203.0/flags/mod.ts";
-import * as unzipit from "npm:unzipit@1.4.3";
+import * as unzipit from "npm:unzipit@1.4";
+import * as z from "npm:zod@3.9";
+import { find_data_dir } from "./jupyter_paths.ts";
 
-type PkgInfoEntry = {
-	packagetype: string;
-	url: string;
-};
-
-type PkgInfo = {
-	info: { version: string };
-	releases: Record<string, PkgInfoEntry[]>;
-	urls: PkgInfoEntry[];
-};
-
-let { version, venv } = flags.parse(Deno.args, {
-	string: ["version", "venv"],
+let ReleaseSchema = z.object({
+	packagetype: z.string(),
+	url: z.string(),
 });
-let pkg_info: PkgInfo = await fetch("https://pypi.org/pypi/anywidget/json")
-	.then((r) => r.json());
 
-let info: PkgInfoEntry[];
-if (version === undefined) {
-	version = pkg_info.info.version;
-	info = pkg_info.urls;
-} else {
-	info = pkg_info.releases[version];
+let PackageSchema = z.object({
+	info: z.object({ version: z.string() }),
+	releases: z.record(z.array(ReleaseSchema)),
+	urls: z.array(ReleaseSchema),
+});
+
+async function fetch_package_info(name: string) {
+	let response = await fetch(`https://pypi.org/pypi/${name}/json`);
+	let json = await response.json();
+	return PackageSchema.parse(json);
 }
 
-if (!info) {
-	console.log("No entries found for version " + version);
-	Deno.exit(1);
+async function fetch_wheel(
+	info: z.infer<typeof PackageSchema>,
+	version?: string,
+): Promise<{ version: string; wheel: Uint8Array }> {
+	let release = version ? info.releases[version] : info.urls;
+	if (!release) {
+		console.log(`No entries found for version ${version}`);
+		Deno.exit(1);
+	}
+	let wheel = release.find((e) => e.packagetype == "bdist_wheel");
+	if (!wheel) {
+		console.log(`No wheel found for version ${version}`);
+		Deno.exit(1);
+	}
+	let response = await fetch(wheel.url);
+	return {
+		version: version ?? info.info.version,
+		wheel: new Uint8Array(await response.arrayBuffer()),
+	};
 }
 
-let wheel = info.find((e) => e.packagetype == "bdist_wheel");
-
-if (!wheel) {
-	console.log("No wheel found for version " + version);
-	Deno.exit(1);
+async function extract_data_files(
+	wheel: ArrayBuffer,
+): Promise<[string, Uint8Array][]> {
+	let archive = await unzipit.unzip(wheel);
+	let data_prefix = /^.*\.data\/data\/share\/jupyter\//;
+	return Promise.all(
+		Object
+			.entries(archive.entries)
+			.filter(([name]) => data_prefix.test(name))
+			.map(async ([name, reader]) => {
+				return [
+					name.replace(data_prefix, ""),
+					new Uint8Array(await reader.arrayBuffer()),
+				];
+			}),
+	);
 }
 
-let archive = await unzipit.unzip(wheel.url);
-let prefix_regex = new RegExp("^anywidget-" + version + ".data/data/");
-let out_dir = path.resolve(venv ?? Deno.env.get("VIRTUAL_ENV") ?? "/usr/local");
+let args = flags.parse(Deno.args, { string: ["version", "venv"] });
+let info = await fetch_package_info("anywidget");
+let { version, wheel } = await fetch_wheel(info, args.version);
+let out_dir = await find_data_dir();
 
 let files = [];
-for (let [name, reader] of Object.entries(archive.entries)) {
-	if (!prefix_regex.test(name)) continue;
-	let file_path = path.resolve(out_dir, name.replace(prefix_regex, ""));
+for (let [data_file_path, bytes] of await extract_data_files(wheel)) {
+	let file_path = path.resolve(out_dir, data_file_path);
 	await fs.ensureFile(file_path);
-	await Deno.writeFile(
-		file_path,
-		new Uint8Array(await reader.arrayBuffer()),
-	);
+	await Deno.writeFile(file_path, bytes);
 	files.push(file_path);
 }
+
+console.log(files.join("\n"));
+
 console.log(`✅ Installed anywidget ${version} in ${out_dir}`);
-console.log(path.join(out_dir, "share/jupyter/labextensions/anywidget/"));
-console.log(path.join(out_dir, "share/jupyter/nbextensions/anywidget/"));
-console.log(
-	path.join(out_dir, "etc/jupyter/nbconfig/notebook.d/anywidget.json"),
-);
+console.log(path.join(out_dir, "labextensions/anywidget/"));
+console.log(path.join(out_dir, "nbextensions/anywidget/"));

--- a/packages/deno/jupyter_paths.ts
+++ b/packages/deno/jupyter_paths.ts
@@ -34,7 +34,7 @@ async function guess_sys_prefix(): Promise<string | undefined> {
  *
  * @ref https://test-jupyter.readthedocs.io/en/rtd-theme/projects/system.html#data-files
  */
-function user_data_dir() {
+export function user_data_dir() {
 	if (Deno.build.os === "windows") {
 		return path.resolve(Deno.env.get("APPDATA")!, "jupyter");
 	}
@@ -50,11 +50,14 @@ function user_data_dir() {
  *
  * @ref https://test-jupyter.readthedocs.io/en/rtd-theme/projects/system.html#data-files
  */
-function system_data_dir() {
+export function system_data_dirs() {
 	if (Deno.build.os === "windows") {
-		return path.resolve(Deno.env.get("PROGRAMDATA")!, "jupyter");
+		return [path.resolve(Deno.env.get("PROGRAMDATA")!, "jupyter")];
 	}
-	return "/usr/local/share/jupyter";
+	return [
+		"/usr/local/share/jupyter",
+		"/usr/share/jupyter",
+	]
 }
 
 /**
@@ -81,5 +84,5 @@ export async function find_data_dir(): Promise<string> {
 	} catch {
 		// Fine, we'll use the system data directory.
 	}
-	return system_data_dir();
+	return system_data_dirs()[0];
 }

--- a/packages/deno/jupyter_paths.ts
+++ b/packages/deno/jupyter_paths.ts
@@ -1,0 +1,85 @@
+// Adapted from https://github.com/nteract/jupyter-paths/blob/main/index.js#L175
+import * as path from "https://deno.land/std@0.203.0/path/mod.ts";
+
+/**
+ * Guesses the sys.prefix for the current Python installation.
+ *
+ * Looks for a python executable in the PATH, and uses the directory.
+ */
+async function guess_sys_prefix(): Promise<string | undefined> {
+	let dirs = (Deno.env.get("PATH") ?? "").split(":");
+	let pathext = Deno.build.os === "windows"
+		? (Deno.env.get("PATHEXT") ?? "").split(";")
+		: [""];
+	for (let dir of dirs) {
+		for (let ext of pathext) {
+			let bin = path.join(dir, `python${ext}`);
+			let stat = await Deno.stat(bin).catch(() => {});
+			if (stat?.isFile) {
+				return Deno.realPath(
+					Deno.build.os === "windows"
+						? path.dirname(bin)
+						: path.dirname(path.dirname(bin)),
+				);
+			}
+		}
+	}
+}
+
+/**
+ * Get the user data directory for Jupyter.
+ *
+ * We could use https://deno.land/x/dir@1.5.1, but it seems
+ * Jupyter paths are a little different.
+ *
+ * @ref https://test-jupyter.readthedocs.io/en/rtd-theme/projects/system.html#data-files
+ */
+function user_data_dir() {
+	if (Deno.build.os === "windows") {
+		return path.resolve(Deno.env.get("APPDATA")!, "jupyter");
+	}
+	if (Deno.build.os === "darwin") {
+		return path.resolve(Deno.env.get("HOME")!, "Library", "Jupyter");
+	}
+	let home = Deno.env.get("XDG_DATA_HOME") ?? Deno.env.get("HOME");
+	return path.resolve(home!, ".local", "share", "jupyter");
+}
+
+/**
+ * Get the system data directory for Jupyter.
+ *
+ * @ref https://test-jupyter.readthedocs.io/en/rtd-theme/projects/system.html#data-files
+ */
+function system_data_dir() {
+	if (Deno.build.os === "windows") {
+		return path.resolve(Deno.env.get("PROGRAMDATA")!, "jupyter");
+	}
+	return "/usr/local/share/jupyter";
+}
+
+/**
+ * Finds a data directory to install anywidget assets into.
+ *
+ * @ref https://test-jupyter.readthedocs.io/en/rtd-theme/projects/system.html#data-files
+ *
+ * Logic is as follows:
+ * 1. If we can determine the sys.prefix, use that.
+ * 2. Otherwise, use the user data directory.
+ * 3. Otherwise, use the system data directory.
+ */
+export async function find_data_dir(): Promise<string> {
+	let sys_prefix = await guess_sys_prefix();
+	if (sys_prefix) {
+		return path.resolve(sys_prefix, "share", "jupyter");
+	}
+	let user_dir = user_data_dir();
+	try {
+		let stat = await Deno.stat(user_dir);
+		if (stat.isDirectory) {
+			return user_dir;
+		}
+	} catch {
+		// Fine, we'll use the system data directory.
+	}
+	return system_data_dir();
+}

--- a/packages/deno/jupyter_paths.ts
+++ b/packages/deno/jupyter_paths.ts
@@ -57,7 +57,7 @@ export function system_data_dirs() {
 	return [
 		"/usr/local/share/jupyter",
 		"/usr/share/jupyter",
-	]
+	];
 }
 
 /**

--- a/packages/deno/mod.ts
+++ b/packages/deno/mod.ts
@@ -1,25 +1,16 @@
 import * as path from "https://deno.land/std@0.203.0/path/mod.ts";
 import mitt, { type Emitter } from "npm:mitt@3";
+import { find_data_dir } from "./jupyter_paths.ts";
 
 let COMMS = new WeakMap<object, Comm>();
 let DEFAULT_VERSION = "0.6.5";
 let ANYWIDGET_VERSION = await find_anywidget_version()
-	.catch(() => {
-		console.warn(
-			`Could not find anywidget version, using default version ${DEFAULT_VERSION}`,
-		);
-		return DEFAULT_VERSION;
-	});
+	.catch(() => DEFAULT_VERSION);
 
 async function find_anywidget_version(): Promise<string> {
-	let venv_path = Deno.env.get("VIRTUAL_ENV") ?? (() => {
-		throw new Error("No virtual environment found");
-	})();
+	let data_dir = await find_data_dir();
 	let contents = await Deno.readTextFile(
-		path.resolve(
-			venv_path,
-			"share/jupyter/labextensions/anywidget/package.json",
-		),
+		path.resolve(data_dir, "labextensions/anywidget/package.json"),
 	);
 	return JSON.parse(contents).version;
 }

--- a/packages/deno/mod.ts
+++ b/packages/deno/mod.ts
@@ -88,7 +88,6 @@ class Comm {
 				},
 			},
 			{
-				"buffers": [],
 				"metadata": {
 					"version":
 						`${this.#protocol_version_major}.${this.#protocol_version_minor}.0`,
@@ -101,8 +100,6 @@ class Comm {
 		await _internals.jupyter_broadcast("comm_msg", {
 			"comm_id": this.id,
 			"data": { "method": "update", "state": state },
-		}, {
-			"buffers": [],
 		});
 	}
 

--- a/packages/deno/mod.ts
+++ b/packages/deno/mod.ts
@@ -88,6 +88,7 @@ class Comm {
 				},
 			},
 			{
+				"buffers": [],
 				"metadata": {
 					"version":
 						`${this.#protocol_version_major}.${this.#protocol_version_minor}.0`,
@@ -100,6 +101,8 @@ class Comm {
 		await _internals.jupyter_broadcast("comm_msg", {
 			"comm_id": this.id,
 			"data": { "method": "update", "state": state },
+		}, {
+				"buffers": [],
 		});
 	}
 

--- a/packages/deno/mod.ts
+++ b/packages/deno/mod.ts
@@ -102,7 +102,7 @@ class Comm {
 			"comm_id": this.id,
 			"data": { "method": "update", "state": state },
 		}, {
-				"buffers": [],
+			"buffers": [],
 		});
 	}
 

--- a/packages/deno/uninstall.ts
+++ b/packages/deno/uninstall.ts
@@ -1,0 +1,29 @@
+import * as path from "https://deno.land/std@0.203.0/path/mod.ts";
+import * as flags from "https://deno.land/std@0.203.0/flags/mod.ts";
+
+let { venv } = flags.parse(Deno.args, {
+	string: ["venv"],
+});
+
+let out_dir = venv ?? Deno.env.get("VIRTUAL_ENV") ?? "/usr/local";
+
+await Deno.readTextFile(
+	path.join(out_dir, "share/jupyter/labextensions/anywidget/package.json"),
+).then((contents) => {
+	const { version } = JSON.parse(contents);
+	console.log(`Uninstalling anywidget@${version}...`);
+}).catch(() => {});
+
+await Deno.remove(
+	path.join(out_dir, "share/jupyter/labextensions/anywidget"),
+	{ recursive: true },
+).catch(() => {});
+
+await Deno.remove(
+	path.join(out_dir, "share/jupyter/nbextensions/anywidget"),
+	{ recursive: true },
+).catch(() => {});
+
+await Deno.remove(
+	path.join(out_dir, "etc/jupyter/nbconfig/notebook.d/anywidget.json"),
+).catch(() => {});

--- a/packages/deno/uninstall.ts
+++ b/packages/deno/uninstall.ts
@@ -1,29 +1,21 @@
 import * as path from "https://deno.land/std@0.203.0/path/mod.ts";
-import * as flags from "https://deno.land/std@0.203.0/flags/mod.ts";
+import { find_data_dir } from "./jupyter_paths.ts";
 
-let { venv } = flags.parse(Deno.args, {
-	string: ["venv"],
-});
-
-let out_dir = venv ?? Deno.env.get("VIRTUAL_ENV") ?? "/usr/local";
+let data_dir = await find_data_dir();
 
 await Deno.readTextFile(
-	path.join(out_dir, "share/jupyter/labextensions/anywidget/package.json"),
+	path.join(data_dir, "labextensions/anywidget/package.json"),
 ).then((contents) => {
 	const { version } = JSON.parse(contents);
 	console.log(`Uninstalling anywidget@${version}...`);
 }).catch(() => {});
 
 await Deno.remove(
-	path.join(out_dir, "share/jupyter/labextensions/anywidget"),
+	path.join(data_dir, "labextensions/anywidget"),
 	{ recursive: true },
 ).catch(() => {});
 
 await Deno.remove(
-	path.join(out_dir, "share/jupyter/nbextensions/anywidget"),
+	path.join(data_dir, "nbextensions/anywidget"),
 	{ recursive: true },
-).catch(() => {});
-
-await Deno.remove(
-	path.join(out_dir, "etc/jupyter/nbconfig/notebook.d/anywidget.json"),
 ).catch(() => {});


### PR DESCRIPTION
Removes the need to `pip install anywidget` for deno kernels. Can just do it with Deno:

```sh
deno run --allow-net --allow-write ./install.ts
```

TODO: Hmm also need to install `@jupyter-widgets/base`...
