### PR TITLE
feat(anywidget): Raise Python error when file is missing

### DIFF
--- a/.changeset/shiny-planes-burn.md
+++ b/.changeset/shiny-planes-burn.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+feat: Rraise Python error when file is missing

--- a/.changeset/shiny-planes-burn.md
+++ b/.changeset/shiny-planes-burn.md
@@ -2,4 +2,4 @@
 "anywidget": patch
 ---
 
-feat: Rraise Python error when file is missing
+feat: Raise Python error when file is missing

--- a/anywidget/_util.py
+++ b/anywidget/_util.py
@@ -192,15 +192,17 @@ def _should_start_thread(path: pathlib.Path) -> bool:
 def try_file_path(x: Any) -> pathlib.Path | None:
     """If possible coerce x into a pathlib.Path object.
 
-    Returns None if x is not a file path.
+    If a string, we handle the following cases:
+
+    - If it's a URL, return None.
+    - If it's a multi-line string, return None.
+    - If it's a single-line string with a file extension, return a pathlib.Path object.
+    - Otherwise, return None.
 
     Parameters
     ----------
-    x : str | pathlib.Path
-        A string that could be:
-        - A URL
-        - Raw file contents
-        - A file path
+    x : Any
+        The object to try to coerce into a pathlib.Path object.
 
     Returns
     -------
@@ -248,4 +250,3 @@ def try_file_contents(x: Any) -> FileContents | None:
         path=path,
         start_thread=_should_start_thread(path),
     )
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,7 +103,8 @@ def test_get_metadata(monkeypatch: pytest.MonkeyPatch):
 def test_try_file_contents_development(tmp_path: pathlib.Path):
     foo = tmp_path / "foo.txt"
 
-    assert try_file_contents(foo) is None
+    with pytest.raises(FileNotFoundError):
+        try_file_contents(foo)
 
     foo.write_text("foo")
     file_contents = try_file_contents(foo)

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -203,6 +203,19 @@ def test_missing_string_path_with_suffix_raises(tmp_path: pathlib.Path):
             _esm = str_path_with_suffix
 
 
+def test_remote_contents():
+    esm = "http://example.com/foo.js"
+    css = "https://example.com/bar.css"
+
+    class Widget(anywidget.AnyWidget):
+        _esm = esm
+        _css = css
+
+    widget = Widget()
+    assert widget._esm == esm
+    assert widget._css == css
+
+
 def test_missing_string_path_without_suffix_is_raw_string(tmp_path: pathlib.Path):
     str_path_without_suffix = str(tmp_path / "foo")
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -185,23 +185,31 @@ def test_infer_file_contents(tmp_path: pathlib.Path):
     Widget._esm.stop_thread()
 
 
-def test_missing_file_no_infer(tmp_path: pathlib.Path):
+def test_missing_pathlib_path_raises(tmp_path: pathlib.Path):
     esm = tmp_path / "foo.js"
-    css = str(tmp_path / "styles.css")
+
+    with pytest.raises(FileNotFoundError):
+
+        class Widget(anywidget.AnyWidget):
+            _esm = esm
+
+
+def test_missing_string_path_with_suffix_raises(tmp_path: pathlib.Path):
+    str_path_with_suffix = str(tmp_path / "foo.js")
+
+    with pytest.raises(FileNotFoundError):
+
+        class Widget(anywidget.AnyWidget):
+            _esm = str_path_with_suffix
+
+
+def test_missing_string_path_without_suffix_is_raw_string(tmp_path: pathlib.Path):
+    str_path_without_suffix = str(tmp_path / "foo")
 
     class Widget(anywidget.AnyWidget):
-        _esm = esm
-        _css = css
+        _esm = str_path_without_suffix
 
-    assert isinstance(Widget._esm, pathlib.Path)
-    assert Widget._esm == esm
-    assert isinstance(Widget._css, str)
-    assert Widget._css == css
-
-    w = Widget()
-
-    assert w._esm == str(tmp_path / "foo.js")
-    assert w._css == css
+    assert Widget()._esm == str_path_without_suffix
 
 
 def test_explicit_file_contents(tmp_path: pathlib.Path):


### PR DESCRIPTION
Fixes #344. This is kind of more tricky than I'd hoped and has to deal with the overloads for `_esm`:

```python
class Widget(anywidget.AnyWidget):
    _esm = "http://localhost:8080/index.js" # a URL
```

```python
class Widget(anywidget.AnyWidget):
    _esm = "index.js" # a string for a path
```

```python
class Widget(anywidget.AnyWidget):
    _esm = """
    export function render({ model, el }) { /* ... */ }
    """ # string for the _contents_ of a file
```

```python
class Widget(anywidget.AnyWidget):
    _esm = pathlib.Path("index.js") # a pathlib.Path object
```

If we are provided a `pathlib.Path` object, we now assert that the file exists. Otherwise, we will try to "guess"
whether the string is 1.) a URL, 2.) raw file contents, or 3.) a file path.

TL;DR – an explicit `pathlib.Path` will always lead to a Python exception if the file is missing, a string for a path will _probably_ raise an exception if the file is missing.
