### PR TITLE
chore: Remove stability warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ Learn more in the
 
 ## Installation
 
-> **Warning**: **anywidget** is new and under active development. It is not yet
-> ready for production as APIs are subject to change.
-
 **anywidget** is available on [PyPI](https://pypi.org/project/anywidget/) and
 may be installed with `pip`:
 


### PR DESCRIPTION
Anywidget is not 1.0, but this warning seems a bit agressive in its current state. Maybe we pick a different warning/phrasing before merging, but the pre-1.0 semver should be a good indicator of stability.
