### PR TITLE
feat!: Drop re-export of `@anywidget/vite` from main package

### DIFF
--- a/.changeset/mean-feet-poke.md
+++ b/.changeset/mean-feet-poke.md
@@ -1,0 +1,9 @@
+---
+"anywidget": minor
+---
+
+Remove re-export of `@anywidget/vite` from main package
+
+Breaking change. If using our Vite plugin, please make sure to install
+`@anywidget/vite` (rather than importing from `anywidget` main package).
+This change allows us to version the Vite plugin and anywidget's core separately.

--- a/packages/anywidget/build.mjs
+++ b/packages/anywidget/build.mjs
@@ -17,16 +17,6 @@ await esbuild.build({
 	outfile: path.join(dist, "index.js"),
 });
 
-// re-export all exports from @anywidget/vite
-await fs.writeFile(
-	path.join(dist, "vite.mjs"),
-	`export * from "@anywidget/vite";`,
-);
-await fs.writeFile(
-	path.join(dist, "vite.cjs"),
-	`module.exports = require("@anywidget/vite");`,
-);
-
 // re-export all exports from @anywidget/types
 await fs.writeFile(
 	path.join(dist, "types.d.ts"),

--- a/packages/anywidget/package.json
+++ b/packages/anywidget/package.json
@@ -10,10 +10,6 @@
 	],
 	"exports": {
 		".": "./dist/index.js",
-		"./vite": {
-			"import": "./dist/vite.mjs",
-			"require": "./dist/vite.cjs"
-		},
 		"./types": {
 			"types": "./dist/types.d.ts",
 			"import": "./dist/types.mjs",


### PR DESCRIPTION
This PR let's us version the Vite plugin and anywidget separately. It is technically a breaking
change for developers using our Vite plugin and importing from `anywidget/vite`.

## Migration

```diff
// vite.config.mjs
import { defineConfig } from "vite";
-- import anywidget from "anywidget/vite";
++ import anywidget from "@anywidget/vite";
```

If you are already using `@anywidget/vite`, there are no changes necessary.
