### PR TITLE
fix(anwidget): Skip `Promise` serialization for ipywidget's `layout`/`style` traits

### DIFF
--- a/.changeset/five-clocks-tell.md
+++ b/.changeset/five-clocks-tell.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+fix: Skip `Promise` serialization for ipywidget's `layout`/`style` traits


### PR DESCRIPTION
Fixes #411. This PR addresses an implicit issue due to ipywidget's default serde. Anywidget doesn't allow for custom serializers, but ipywidget's serialization of `layout`/`style` traits seems to have a race condition where `unpack_models` returns a `Promise` that is omitted with the default `JSON.stringify(JSON.parse(...))` trick. 

This mimics the current behavior of ipywidgets, but explicitly the special case where `layout` and `style` are Promises. We do this rather than falling back to JSON.stringify + JSON.parse to that users will see errors if they accidentally do the same.

