### PR TITLE
feat: Add a example notebook to the cookiecutter

### DIFF
--- a/.changeset/olive-dragons-notice.md
+++ b/.changeset/olive-dragons-notice.md
@@ -1,0 +1,5 @@
+---
+"create-anywidget": patch
+---
+
+feat: Add example.ipynb to all projects

--- a/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
@@ -12,6 +12,30 @@ pip install undefined
     "path": "README.md",
   },
   {
+    "content": "{
+	"cells": [
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {},
+			"outputs": [],
+			"source": [
+				"from undefined import Counter\\n",
+				"Counter()"
+			]
+		}
+	],
+	"metadata": {
+		"language_info": {
+			"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}",
+    "path": "example.ipynb",
+  },
+  {
     "content": "node_modules
 .venv
 dist
@@ -154,6 +178,30 @@ pip install undefined
 \`\`\`
 ",
     "path": "README.md",
+  },
+  {
+    "content": "{
+	"cells": [
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {},
+			"outputs": [],
+			"source": [
+				"from undefined import Counter\\n",
+				"Counter()"
+			]
+		}
+	],
+	"metadata": {
+		"language_info": {
+			"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}",
+    "path": "example.ipynb",
   },
   {
     "content": "node_modules
@@ -332,6 +380,30 @@ pip install undefined
     "path": "README.md",
   },
   {
+    "content": "{
+	"cells": [
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {},
+			"outputs": [],
+			"source": [
+				"from undefined import Counter\\n",
+				"Counter()"
+			]
+		}
+	],
+	"metadata": {
+		"language_info": {
+			"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}",
+    "path": "example.ipynb",
+  },
+  {
     "content": "node_modules
 .venv
 dist
@@ -470,6 +542,30 @@ pip install undefined
 \`\`\`
 ",
     "path": "README.md",
+  },
+  {
+    "content": "{
+	"cells": [
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {},
+			"outputs": [],
+			"source": [
+				"from undefined import Counter\\n",
+				"Counter()"
+			]
+		}
+	],
+	"metadata": {
+		"language_info": {
+			"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}",
+    "path": "example.ipynb",
   },
   {
     "content": "[build-system]
@@ -611,6 +707,30 @@ pip install undefined
 \`\`\`
 ",
     "path": "README.md",
+  },
+  {
+    "content": "{
+	"cells": [
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {},
+			"outputs": [],
+			"source": [
+				"from undefined import Counter\\n",
+				"Counter()"
+			]
+		}
+	],
+	"metadata": {
+		"language_info": {
+			"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}",
+    "path": "example.ipynb",
   },
   {
     "content": "node_modules
@@ -791,6 +911,30 @@ pip install undefined
     "path": "README.md",
   },
   {
+    "content": "{
+	"cells": [
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {},
+			"outputs": [],
+			"source": [
+				"from undefined import Counter\\n",
+				"Counter()"
+			]
+		}
+	],
+	"metadata": {
+		"language_info": {
+			"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}",
+    "path": "example.ipynb",
+  },
+  {
     "content": "node_modules
 .venv
 dist
@@ -933,6 +1077,30 @@ pip install undefined
 \`\`\`
 ",
     "path": "README.md",
+  },
+  {
+    "content": "{
+	"cells": [
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {},
+			"outputs": [],
+			"source": [
+				"from undefined import Counter\\n",
+				"Counter()"
+			]
+		}
+	],
+	"metadata": {
+		"language_info": {
+			"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}",
+    "path": "example.ipynb",
   },
   {
     "content": "node_modules
@@ -1111,6 +1279,30 @@ pip install undefined
     "path": "README.md",
   },
   {
+    "content": "{
+	"cells": [
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {},
+			"outputs": [],
+			"source": [
+				"from undefined import Counter\\n",
+				"Counter()"
+			]
+		}
+	],
+	"metadata": {
+		"language_info": {
+			"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}",
+    "path": "example.ipynb",
+  },
+  {
     "content": "node_modules
 .venv
 dist
@@ -1249,6 +1441,30 @@ pip install undefined
 \`\`\`
 ",
     "path": "README.md",
+  },
+  {
+    "content": "{
+	"cells": [
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {},
+			"outputs": [],
+			"source": [
+				"from undefined import Counter\\n",
+				"Counter()"
+			]
+		}
+	],
+	"metadata": {
+		"language_info": {
+			"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}",
+    "path": "example.ipynb",
   },
   {
     "content": "[build-system]
@@ -1390,6 +1606,30 @@ pip install undefined
 \`\`\`
 ",
     "path": "README.md",
+  },
+  {
+    "content": "{
+	"cells": [
+		{
+			"cell_type": "code",
+			"execution_count": null,
+			"metadata": {},
+			"outputs": [],
+			"source": [
+				"from undefined import Counter\\n",
+				"Counter()"
+			]
+		}
+	],
+	"metadata": {
+		"language_info": {
+			"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+}",
+    "path": "example.ipynb",
   },
   {
     "content": "node_modules

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -155,6 +155,32 @@ pip install ${name}
 \`\`\`
 `;
 
+
+/** @param {string} name */
+let notebook = (name) =>
+	`{
+	"cells": [
+		{
+		"cell_type": "code",
+		"execution_count": null,
+		"metadata": {},
+		"outputs": [],
+		"source": [
+		"from ${name} import Counter\\n",
+		"Counter()"
+		]
+		}
+	],
+	"metadata": {
+		"language_info": {
+		"name": "python"
+		}
+	},
+	"nbformat": 4,
+	"nbformat_minor": 2
+	}`;
+
+
 /** @param {string} name */
 let styles = (name) =>
 	`\
@@ -393,6 +419,8 @@ async function render_template(template, { name, pkg_manager }) {
 	}));
 	return [
 		{ path: `README.md`, content: readme(name) },
+		{ path: `example.ipynb`, content: notebook(name) },
+
 		{ path: `.gitignore`, content: gitignore([`src/${name}/static`]) },
 		{ path: `package.json`, content: json_dumps(package_json) },
 		{
@@ -453,6 +481,7 @@ export async function gather_files(type, { name, pkg_manager }) {
 	if (type === "template-vanilla-deno-jsdoc") {
 		return [
 			{ path: `README.md`, content: readme(name) },
+			{ path: `example.ipynb`, content: notebook(name) },
 			{ path: `pyproject.toml`, content: pyproject_toml(name) },
 			{ path: `deno.json`, content: json_dumps(deno_json) },
 			{ path: `.gitignore`, content: gitignore() },

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -155,31 +155,29 @@ pip install ${name}
 \`\`\`
 `;
 
-
 /** @param {string} name */
 let notebook = (name) =>
-	`{
-	"cells": [
-		{
-		"cell_type": "code",
-		"execution_count": null,
-		"metadata": {},
-		"outputs": [],
-		"source": [
-		"from ${name} import Counter\\n",
-		"Counter()"
-		]
-		}
-	],
-	"metadata": {
-		"language_info": {
-		"name": "python"
-		}
-	},
-	"nbformat": 4,
-	"nbformat_minor": 2
-	}`;
-
+	json_dumps({
+		"cells": [
+			{
+				"cell_type": "code",
+				"execution_count": null,
+				"metadata": {},
+				"outputs": [],
+				"source": [
+					`from ${name} import Counter\n`,
+					"Counter()",
+				],
+			},
+		],
+		"metadata": {
+			"language_info": {
+				"name": "python",
+			},
+		},
+		"nbformat": 4,
+		"nbformat_minor": 2,
+	});
 
 /** @param {string} name */
 let styles = (name) =>


### PR DESCRIPTION
I've tested all 5 options with 

cd packages/create-anywidget
npm install
node index.js

there was one tricky part:
"from ${name} import Counter\n",
had to be replaced with 
"from ${name} import Counter\\n",

but now everything works fine.