### PR TITLE
feat(anywidget): Make HMR explicit and opt-in

### DIFF
--- a/.changeset/shiny-houses-run.md
+++ b/.changeset/shiny-houses-run.md
@@ -1,0 +1,5 @@
+---
+"anywidget": minor
+---
+
+feat: Require explicit opt-in to HMR during development

--- a/.changeset/shiny-houses-run.md
+++ b/.changeset/shiny-houses-run.md
@@ -2,4 +2,4 @@
 "anywidget": minor
 ---
 
-feat: Require explicit opt-in to HMR during development
+feat: Require `ANYWIDGET_HMR` to opt-in to HMR during development

--- a/anywidget/_util.py
+++ b/anywidget/_util.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import pathlib
 import re
 import sys
@@ -164,6 +165,10 @@ def get_repr_metadata() -> dict:
     return {_WIDGET_MIME_TYPE: {"colab": {"custom_widget_manager": {"url": url}}}}
 
 
+def _is_hmr_enabled() -> bool:
+    return os.getenv("ANYWIDGET_HMR") == "1"
+
+
 def _should_start_thread(path: pathlib.Path) -> bool:
     if "site-packages" in path.parts:
         # File is inside site-packages, likely not a local development install
@@ -171,6 +176,10 @@ def _should_start_thread(path: pathlib.Path) -> bool:
 
     if "dist-packages" in path.parts:
         # Debian-specific directory, where python packages are installed in Colab.
+        return False
+
+    # If we're in dev mode, we should start a thread to watch the file for changes.
+    if not _is_hmr_enabled():
         return False
 
     try:

--- a/anywidget/experimental.py
+++ b/anywidget/experimental.py
@@ -37,7 +37,7 @@ def widget(
         kwargs["_css"] = css
 
     def _decorator(cls: ModelT) -> ModelT:
-        cls._repr_mimebundle_ = MimeBundleDescriptor(**kwargs)
+        setattr(cls, "_repr_mimebundle_", MimeBundleDescriptor(**kwargs))
         return cls
 
     return _decorator

--- a/anywidget/experimental.py
+++ b/anywidget/experimental.py
@@ -37,7 +37,7 @@ def widget(
         kwargs["_css"] = css
 
     def _decorator(cls: ModelT) -> ModelT:
-        setattr(cls, "_repr_mimebundle_", MimeBundleDescriptor(**kwargs))
+        cls._repr_mimebundle_ = MimeBundleDescriptor(**kwargs)
         return cls
 
     return _decorator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ pattern = "\"version\": \"(?P<version>.+?)\""
 
 [tool.hatch.envs.default]
 features = ["test", "dev"]
+python = "3.11"
 
 [tool.hatch.envs.default.scripts]
 lint = [

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -193,7 +193,7 @@ def test_descriptor_on_slots() -> None:
     class Foo:
         __slots__ = ()
 
-        _repr_mimebundle_ = MimeBundleDescriptor()
+        _repr_mimebundle_ = MimeBundleDescriptor(autodetect_observer=False)
         value: int = 1
 
         def _get_anywidget_state(self, include: Union[Set[str], None]):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,6 +111,16 @@ def test_try_file_contents_development(tmp_path: pathlib.Path):
         try_file_contents(foo)
 
     foo.write_text("foo")
+    assert try_file_contents(foo) is not None
+
+
+def test_try_file_contents_development_enable_hmr(tmp_path: pathlib.Path):
+    foo = tmp_path / "foo.txt"
+
+    with pytest.raises(FileNotFoundError):
+        try_file_contents(foo)
+
+    foo.write_text("foo")
     with enable_hmr():
         file_contents = try_file_contents(foo)
     assert isinstance(file_contents, FileContents)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pathlib
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from anywidget._file_contents import FileContents
@@ -10,6 +10,10 @@ from anywidget._util import (
     remove_buffers,
     try_file_contents,
 )
+
+
+def enable_hmr():
+    return patch.dict("os.environ", {"ANYWIDGET_HMR": "1"}, clear=True)
 
 
 def test_remove_and_put_buffers():
@@ -107,7 +111,8 @@ def test_try_file_contents_development(tmp_path: pathlib.Path):
         try_file_contents(foo)
 
     foo.write_text("foo")
-    file_contents = try_file_contents(foo)
+    with enable_hmr():
+        file_contents = try_file_contents(foo)
     assert isinstance(file_contents, FileContents)
     assert file_contents._background_thread is not None
     file_contents.stop_thread()  # stop the background thread for CI
@@ -139,12 +144,12 @@ def test_try_file_contents_warns(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ):
     monkeypatch.setitem(sys.modules, "watchfiles", None)
-
     foo = tmp_path / "foo.txt"
     foo.write_text("foo")
 
-    with pytest.warns(UserWarning, match="anywidget:"):
-        file_contents = try_file_contents(foo)
+    with enable_hmr():
+        with pytest.warns(UserWarning, match="anywidget:"):
+            file_contents = try_file_contents(foo)
 
-    assert isinstance(file_contents, FileContents)
-    assert file_contents._background_thread is None
+        assert isinstance(file_contents, FileContents)
+        assert file_contents._background_thread is None

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -2,7 +2,9 @@ import json
 import pathlib
 import sys
 import time
+
 from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import anywidget
 import pytest
@@ -144,9 +146,10 @@ def test_infer_file_contents(tmp_path: pathlib.Path):
     css = site_packages / "styles.css"
     css.write_text(".foo { background-color: black; }")
 
-    class Widget(anywidget.AnyWidget):
-        _esm = esm
-        _css = str(css)
+    with mock.patch.dict('os.environ', {'ANYWIDGET_HMR': '1'}, clear=True):
+        class Widget(anywidget.AnyWidget):
+            _esm = esm
+            _css = str(css)
 
     assert isinstance(Widget._esm, FileContents)
     assert Widget._esm._background_thread is not None

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -2,9 +2,7 @@ import json
 import pathlib
 import sys
 import time
-
 from unittest.mock import MagicMock, patch
-from unittest import mock
 
 import anywidget
 import pytest
@@ -17,6 +15,8 @@ from watchfiles import Change
 
 here = pathlib.Path(__file__).parent
 
+def enable_hmr():
+    return patch.dict("os.environ", {"ANYWIDGET_HMR": "1"}, clear=True)
 
 def test_version():
     with open(here / "../packages/anywidget/package.json") as f:
@@ -146,7 +146,7 @@ def test_infer_file_contents(tmp_path: pathlib.Path):
     css = site_packages / "styles.css"
     css.write_text(".foo { background-color: black; }")
 
-    with mock.patch.dict('os.environ', {'ANYWIDGET_HMR': '1'}, clear=True):
+    with enable_hmr():
         class Widget(anywidget.AnyWidget):
             _esm = esm
             _css = str(css)

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -15,8 +15,10 @@ from watchfiles import Change
 
 here = pathlib.Path(__file__).parent
 
+
 def enable_hmr():
     return patch.dict("os.environ", {"ANYWIDGET_HMR": "1"}, clear=True)
+
 
 def test_version():
     with open(here / "../packages/anywidget/package.json") as f:
@@ -147,6 +149,7 @@ def test_infer_file_contents(tmp_path: pathlib.Path):
     css.write_text(".foo { background-color: black; }")
 
     with enable_hmr():
+
         class Widget(anywidget.AnyWidget):
             _esm = esm
             _css = str(css)


### PR DESCRIPTION
Fixes #423 #374 

## What

Makes anywidget's native HMR explicit and opt-in via the `ANYWIDGET_HMR` environment variable. 

## Context

The built-in HMR is only meant to be used during "live" development, when _local_ widgets are in imported and used in an active notebook. However, our heuristics for enabling this development feature lead to many false positives, and thus issues  issues in various non- "live" development settings #423, #374, #276.

**This is a bad experience for end users**. 

It doesn't seem possible to account for all these edge cases, and since HMR is meant as a development only feature, it makes sense to make it explicit and opt-in _by the developer_. This PR requires an environment variable to apply anywidget's prior heuristics. It can be set in a notebook:

```python
%env ANYWIDGET_HMR=1
```

or when launching a notebook from the command line:

```python
ANYWIDGET_HMR=1 jupyter lab
```