### PR TITLE
Fix mock assert

### DIFF
--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -134,7 +134,7 @@ def test_patched_repr_ipywidget_v8(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setitem(sys.modules, "google.colab.output", mock)
 
     w = anywidget.AnyWidget()
-    assert mock.enable_custom_widget_manager.called_once
+    assert mock.enable_custom_widget_manager.assert_called_once
 
     bundle = w._repr_mimebundle_()
     assert bundle[0] and _WIDGET_MIME_TYPE in bundle[0]


### PR DESCRIPTION
Fix a test failure on Python 3.12:

```python
[   68s] =================================== FAILURES ===================================
[   68s] ________________________ test_patched_repr_ipywidget_v8 ________________________
[   68s] 
[   68s] monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7fdb6fb4c2f0>
[   68s] 
[   68s]     def test_patched_repr_ipywidget_v8(monkeypatch: pytest.MonkeyPatch):
[   68s]         w = anywidget.AnyWidget()
[   68s]         bundle = w._repr_mimebundle_()
[   68s]         assert bundle[0] and _WIDGET_MIME_TYPE in bundle[0]
[   68s]         assert bundle[1] == {}
[   68s]     
[   68s]         mock = MagicMock()
[   68s]         mock._installed_url = "foo"
[   68s]         monkeypatch.setitem(sys.modules, "google.colab.output", mock)
[   68s]     
[   68s]         w = anywidget.AnyWidget()
[   68s] >       assert mock.enable_custom_widget_manager.called_once
[   68s] 
[   68s] tests/test_widget.py:137: 
[   68s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[   68s] 
[   68s] self = <MagicMock name='mock.enable_custom_widget_manager' id='140580448634112'>
[   68s] name = 'called_once'
[   68s] 
[   68s]     def __getattr__(self, name):
[   68s]         if name in {'_mock_methods', '_mock_unsafe'}:
[   68s]             raise AttributeError(name)
[   68s]         elif self._mock_methods is not None:
[   68s]             if name not in self._mock_methods or name in _all_magics:
[   68s]                 raise AttributeError("Mock object has no attribute %r" % name)
[   68s]         elif _is_magic(name):
[   68s]             raise AttributeError(name)
[   68s]         if not self._mock_unsafe and (not self._mock_methods or name not in self._mock_methods):
[   68s]             if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')) or name in _ATTRIB_DENY_LIST:
[   68s] >               raise AttributeError(
[   68s]                     f"{name!r} is not a valid assertion. Use a spec "
[   68s]                     f"for the mock if {name!r} is meant to be an attribute.")
[   68s] E               AttributeError: 'called_once' is not a valid assertion. Use a spec for the mock if 'called_once' is meant to be an attribute.
[   68s] 
[   68s] /usr/lib64/python3.12/unittest/mock.py:663: AttributeError
[   68s] =========================== short test summary info ============================
[   68s] FAILED tests/test_widget.py::test_patched_repr_ipywidget_v8 - AttributeError:...
[   68s] ========================= 1 failed, 42 passed in 0.60s =========================

```