### PR TITLE
feat!: Add support for Python 3.12 and drop Python 3.7

### DIFF
--- a/.changeset/clever-houses-float.md
+++ b/.changeset/clever-houses-float.md
@@ -1,0 +1,5 @@
+---
+"anywidget": minor
+---
+
+Drop support for Python 3.7 and add Python 3.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/anywidget/package.json
+++ b/packages/anywidget/package.json
@@ -26,8 +26,8 @@
 		"solid-js": "^1.8.14"
 	},
 	"devDependencies": {
-		"@jupyter-widgets/base-manager": "^1.0.6",
-		"@jupyterlab/builder": "^3.6.5"
+		"@jupyter-widgets/base-manager": "^1.0.8",
+		"@jupyterlab/builder": "^4.1.0"
 	},
 	"jupyterlab": {
 		"extension": "src/plugin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,11 +116,11 @@ importers:
         version: 1.8.14
     devDependencies:
       '@jupyter-widgets/base-manager':
-        specifier: ^1.0.6
-        version: 1.0.7(react@18.2.0)
+        specifier: ^1.0.8
+        version: 1.0.8(react@18.2.0)
       '@jupyterlab/builder':
-        specifier: ^3.6.5
-        version: 3.6.5(crypto@1.0.1)(esbuild@0.20.0)
+        specifier: ^4.1.0
+        version: 4.1.0(esbuild@0.20.0)
 
   packages/create-anywidget:
     dependencies:
@@ -1795,10 +1795,6 @@ packages:
     dev: true
     optional: true
 
-  /@gar/promisify@1.1.3:
-    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
-    dev: true
-
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1838,11 +1834,11 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@jupyter-widgets/base-manager@1.0.7(react@18.2.0):
-    resolution: {integrity: sha512-hxoye9e8QOuiWGI/qLno4OqAGWefmJ+2/rzurVAc4bSBiOL13rWCZmG6aRaRS0wnEPrm9eGGpF+NJzoGkJAx+w==}
+  /@jupyter-widgets/base-manager@1.0.8(react@18.2.0):
+    resolution: {integrity: sha512-6Knzl0AzBkMvadj748Hf6R//w2FlgMWg1vA4eWe4Mvff6mINZNWpCObwbvpvCjxnAnsGa81JXnmuF2y61KZoBg==}
     dependencies:
-      '@jupyter-widgets/base': 6.0.6(react@18.2.0)
-      '@jupyterlab/services': 7.0.6(react@18.2.0)
+      '@jupyter-widgets/base': 6.0.7(react@18.2.0)
+      '@jupyterlab/services': 7.0.7(react@18.2.0)
       '@lumino/coreutils': 2.1.2
       base64-js: 1.5.1
       sanitize-html: 2.11.0
@@ -1868,16 +1864,24 @@ packages:
       - bufferutil
       - react
       - utf-8-validate
+    dev: false
 
-  /@jupyter/ydoc@1.0.2:
-    resolution: {integrity: sha512-0zG/5FcntGXtCC3BQYWHZlGJpRIdeV0sF7q0i3ZtS7AdhMZdyILObQGwbHpybEPENdv1HRKW/J+CGhNSriG+KQ==}
+  /@jupyter-widgets/base@6.0.7(react@18.2.0):
+    resolution: {integrity: sha512-a4VoUtL+90mGH6VE6m78D2J9aNy9Q1JrPP91HAQTXBysVpCLTtq0Ie8EupN5Su7V8eFwl/wz91J2m0p4jY4h0g==}
     dependencies:
-      '@jupyterlab/nbformat': 4.0.6
+      '@jupyterlab/services': 7.0.7(react@18.2.0)
       '@lumino/coreutils': 2.1.2
-      '@lumino/disposable': 2.1.2
-      '@lumino/signaling': 2.1.2
-      y-protocols: 1.0.5
-      yjs: 13.6.7
+      '@lumino/messaging': 1.10.3
+      '@lumino/widgets': 2.3.0
+      '@types/backbone': 1.4.14
+      '@types/lodash': 4.14.200
+      backbone: 1.4.0
+      jquery: 3.7.1
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - bufferutil
+      - react
+      - utf-8-validate
     dev: true
 
   /@jupyter/ydoc@1.1.1:
@@ -1890,66 +1894,49 @@ packages:
       y-protocols: 1.0.6(yjs@13.6.8)
       yjs: 13.6.8
 
-  /@jupyterlab/builder@3.6.5(crypto@1.0.1)(esbuild@0.20.0):
-    resolution: {integrity: sha512-J9WO50gxjJ1bUo7BCix0fSxpRySCwaR8AaWNQ5QdYT1ARSGuSnfM9ZyeUOS61DvL3+h7IqsPTQQr5tbhIWv91Q==}
+  /@jupyterlab/builder@4.1.0(esbuild@0.20.0):
+    resolution: {integrity: sha512-SSNWhnCr2wodun9IolmxaXGIsn2GsLee4pT3c9D5ckHgo8fmuJxM6MTyGXFEQCwNWgkzNm5ZgJpYrZrrzAt6ZA==}
     hasBin: true
     dependencies:
-      '@lumino/algorithm': 1.9.2
-      '@lumino/application': 1.31.4(crypto@1.0.1)
-      '@lumino/commands': 1.21.1(crypto@1.0.1)
-      '@lumino/coreutils': 1.12.1(crypto@1.0.1)
-      '@lumino/disposable': 1.10.4
-      '@lumino/domutils': 1.8.2
-      '@lumino/dragdrop': 1.14.5(crypto@1.0.1)
-      '@lumino/messaging': 1.10.3
-      '@lumino/properties': 1.8.2
-      '@lumino/signaling': 1.11.1
-      '@lumino/virtualdom': 1.14.3
-      '@lumino/widgets': 1.37.2(crypto@1.0.1)
-      ajv: 6.12.6
-      commander: 6.0.0
-      css-loader: 5.2.7(webpack@5.88.2)
+      '@lumino/algorithm': 2.0.1
+      '@lumino/application': 2.3.0
+      '@lumino/commands': 2.2.0
+      '@lumino/coreutils': 2.1.2
+      '@lumino/disposable': 2.1.2
+      '@lumino/domutils': 2.0.1
+      '@lumino/dragdrop': 2.1.4
+      '@lumino/messaging': 2.0.1
+      '@lumino/properties': 2.0.1
+      '@lumino/signaling': 2.1.2
+      '@lumino/virtualdom': 2.0.1
+      '@lumino/widgets': 2.3.1
+      ajv: 8.12.0
+      commander: 9.5.0
+      css-loader: 6.10.0(webpack@5.88.2)
       duplicate-package-checker-webpack-plugin: 3.0.0
-      file-loader: 6.0.0(webpack@5.88.2)
-      fs-extra: 9.1.0
+      fs-extra: 10.1.0
       glob: 7.1.7
       license-webpack-plugin: 2.3.21(webpack@5.88.2)
-      mini-css-extract-plugin: 1.3.9(webpack@5.88.2)
+      mini-css-extract-plugin: 2.8.0(webpack@5.88.2)
+      mini-svg-data-uri: 1.4.4
       path-browserify: 1.0.1
       process: 0.11.10
-      raw-loader: 4.0.2(webpack@5.88.2)
       source-map-loader: 1.0.2(webpack@5.88.2)
-      style-loader: 2.0.0(webpack@5.88.2)
+      style-loader: 3.3.4(webpack@5.88.2)
       supports-color: 7.2.0
-      svg-url-loader: 6.0.0(webpack@5.88.2)
-      terser-webpack-plugin: 4.2.3(webpack@5.88.2)
-      to-string-loader: 1.2.0
-      url-loader: 4.1.1(file-loader@6.0.0)(webpack@5.88.2)
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(esbuild@0.20.0)(webpack@5.88.2)
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack@5.88.2)
       webpack-merge: 5.9.0
       worker-loader: 3.0.8(webpack@5.88.2)
     transitivePeerDependencies:
+      - '@rspack/core'
       - '@swc/core'
       - '@webpack-cli/generators'
-      - '@webpack-cli/migrate'
-      - bluebird
-      - crypto
       - esbuild
       - uglify-js
       - webpack-bundle-analyzer
       - webpack-dev-server
-    dev: true
-
-  /@jupyterlab/coreutils@6.0.6:
-    resolution: {integrity: sha512-riQ6hXa3uU9GyhkcYPo+F2SC7DumgdDlkmewtu5wxUTDO0x+ZVhEC++pA7+nUszqouRvLk1lb05bfrmKgyYA4Q==}
-    dependencies:
-      '@lumino/coreutils': 2.1.2
-      '@lumino/disposable': 2.1.2
-      '@lumino/signaling': 2.1.2
-      minimist: 1.2.8
-      path-browserify: 1.0.1
-      url-parse: 1.5.10
     dev: true
 
   /@jupyterlab/coreutils@6.0.7:
@@ -1962,36 +1949,10 @@ packages:
       path-browserify: 1.0.1
       url-parse: 1.5.10
 
-  /@jupyterlab/nbformat@4.0.6:
-    resolution: {integrity: sha512-bfpNKosc+Ayx8rdY8cSJJCmhw8x3e8nqkv865VremsMtwLTv3KvXvzz8xNW3dxp/V9Led+dfGKm8uyds7V4tEg==}
-    dependencies:
-      '@lumino/coreutils': 2.1.2
-    dev: true
-
   /@jupyterlab/nbformat@4.0.7:
     resolution: {integrity: sha512-nC5kAqgc/6m2ApEBVUnRjPO4yJyDyX0b4wpUl7QjCcr/qcnIPV23yYCKFeV7wjk/8nj6ZvXRIuMgRaTE8jHoGw==}
     dependencies:
       '@lumino/coreutils': 2.1.2
-
-  /@jupyterlab/services@7.0.6(react@18.2.0):
-    resolution: {integrity: sha512-RRDCjpisHiAF30RxpGENUz8eJXNt5TDt8M9ftTojy5eUKWkI1MAA9CvM9E5kc4JCX9RgqXUCvi9Vb+mvw+sCTg==}
-    dependencies:
-      '@jupyter/ydoc': 1.0.2
-      '@jupyterlab/coreutils': 6.0.6
-      '@jupyterlab/nbformat': 4.0.6
-      '@jupyterlab/settingregistry': 4.0.6(react@18.2.0)
-      '@jupyterlab/statedb': 4.0.6
-      '@lumino/coreutils': 2.1.2
-      '@lumino/disposable': 2.1.2
-      '@lumino/polling': 2.1.2
-      '@lumino/properties': 2.0.1
-      '@lumino/signaling': 2.1.2
-      ws: 8.14.1
-    transitivePeerDependencies:
-      - bufferutil
-      - react
-      - utf-8-validate
-    dev: true
 
   /@jupyterlab/services@7.0.7(react@18.2.0):
     resolution: {integrity: sha512-i8wv0aIQFndfkaXqDhuHv4C+KncmlBBXR8H/jwCZivnDreyDBDBJril5XDnwgPFIUOJUVxOU6J4Q3B5ySAso2Q==}
@@ -2012,23 +1973,6 @@ packages:
       - react
       - utf-8-validate
 
-  /@jupyterlab/settingregistry@4.0.6(react@18.2.0):
-    resolution: {integrity: sha512-GGLqDYd9M8E8QwxgCw/Bcc+hJkDkPxaBTMu5gUvRWgnDUlrtO+pmRNcf6VTfq1s/Z7WMtdDLMn98OBVd7ZMx5g==}
-    peerDependencies:
-      react: '>=16'
-    dependencies:
-      '@jupyterlab/nbformat': 4.0.6
-      '@jupyterlab/statedb': 4.0.6
-      '@lumino/commands': 2.1.3
-      '@lumino/coreutils': 2.1.2
-      '@lumino/disposable': 2.1.2
-      '@lumino/signaling': 2.1.2
-      '@rjsf/utils': 5.13.0(react@18.2.0)
-      ajv: 8.12.0
-      json5: 2.2.3
-      react: 18.2.0
-    dev: true
-
   /@jupyterlab/settingregistry@4.0.7(react@18.2.0):
     resolution: {integrity: sha512-BYbYF1Q6q4Fc6MHeRLeLIFpDPpfnRDkhP9uHNV6AxDs27p2CP7W26Vrt7mUQ8RpQh+padOY582FWhoPE0ZIieQ==}
     peerDependencies:
@@ -2045,16 +1989,6 @@ packages:
       json5: 2.2.3
       react: 18.2.0
 
-  /@jupyterlab/statedb@4.0.6:
-    resolution: {integrity: sha512-KYEh+sH5CKS9h7Zze22IWH6n266xz8jaWzHY3nrykQTwxwZpeAA+p9asiorttR7qdl97Oi3BmWGiQ+HVb2HR0Q==}
-    dependencies:
-      '@lumino/commands': 2.1.3
-      '@lumino/coreutils': 2.1.2
-      '@lumino/disposable': 2.1.2
-      '@lumino/properties': 2.0.1
-      '@lumino/signaling': 2.1.2
-    dev: true
-
   /@jupyterlab/statedb@4.0.7:
     resolution: {integrity: sha512-yGqSu9hF/dy7/X6lvmxlWyfbiHqxH4sb/WRAaJGbqUrqvXaX2PXl0m4zlWtehxBnJ6Yw+ROCBr/mc0k52mlvjQ==}
     dependencies:
@@ -2070,14 +2004,12 @@ packages:
   /@lumino/algorithm@2.0.1:
     resolution: {integrity: sha512-iA+uuvA7DeNFB0/cQpIWNgO1c6z4pOSigifjstLy+rxf1U5ZzxIq+xudnEuTbWgKSTviG02j4cKwCyx1PO6rzA==}
 
-  /@lumino/application@1.31.4(crypto@1.0.1):
-    resolution: {integrity: sha512-dOSsDJ1tXOxC3fnSHvtDQK5RcICLEVPtO19HeCGwurb5W2ZZ55SZT2b5jZu6V/v8lGdtkNbr1RJltRpJRSRb/A==}
+  /@lumino/application@2.3.0:
+    resolution: {integrity: sha512-08jqDsjciXtK4yy/8o01qf9qxYYxzbYO1FkTu+ucV+jmbVkfAQuS1ApLIgmMiTbLw45SWUwk+x+TnCgVQZaDzA==}
     dependencies:
-      '@lumino/commands': 1.21.1(crypto@1.0.1)
-      '@lumino/coreutils': 1.12.1(crypto@1.0.1)
-      '@lumino/widgets': 1.37.2(crypto@1.0.1)
-    transitivePeerDependencies:
-      - crypto
+      '@lumino/commands': 2.2.0
+      '@lumino/coreutils': 2.1.2
+      '@lumino/widgets': 2.3.1
     dev: true
 
   /@lumino/collections@1.9.3:
@@ -2090,20 +2022,6 @@ packages:
     dependencies:
       '@lumino/algorithm': 2.0.1
 
-  /@lumino/commands@1.21.1(crypto@1.0.1):
-    resolution: {integrity: sha512-d1zJmwz5bHU0BM/Rl3tRdZ7/WgXnFB0bM7x7Bf0XDlmX++jnU9k0j3mh6/5JqCGLmIApKCRwVqSaV7jPmSJlcQ==}
-    dependencies:
-      '@lumino/algorithm': 1.9.2
-      '@lumino/coreutils': 1.12.1(crypto@1.0.1)
-      '@lumino/disposable': 1.10.4
-      '@lumino/domutils': 1.8.2
-      '@lumino/keyboard': 1.8.2
-      '@lumino/signaling': 1.11.1
-      '@lumino/virtualdom': 1.14.3
-    transitivePeerDependencies:
-      - crypto
-    dev: true
-
   /@lumino/commands@2.1.3:
     resolution: {integrity: sha512-F0ZYZDrfJzcPp4JqeQMC2dzi3XOobzNZD94qUJ6QBsbfghFRcPBM+rfOspghRvCEFHAZdtghw04wOp7VWgIczA==}
     dependencies:
@@ -2115,44 +2033,28 @@ packages:
       '@lumino/signaling': 2.1.2
       '@lumino/virtualdom': 2.0.1
 
-  /@lumino/coreutils@1.12.1(crypto@1.0.1):
-    resolution: {integrity: sha512-JLu3nTHzJk9N8ohZ85u75YxemMrmDzJdNgZztfP7F7T7mxND3YVNCkJG35a6aJ7edu1sIgCjBxOvV+hv27iYvQ==}
-    peerDependencies:
-      crypto: 1.0.1
+  /@lumino/commands@2.2.0:
+    resolution: {integrity: sha512-xm+4rFithAd/DLZheQcS0GJaI3m0gVg07mCEZAWBLolN5e7w6XTr17VuD7J6KSjdBygMKZ3n8GlEkpcRNWEajA==}
     dependencies:
-      crypto: 1.0.1
+      '@lumino/algorithm': 2.0.1
+      '@lumino/coreutils': 2.1.2
+      '@lumino/disposable': 2.1.2
+      '@lumino/domutils': 2.0.1
+      '@lumino/keyboard': 2.0.1
+      '@lumino/signaling': 2.1.2
+      '@lumino/virtualdom': 2.0.1
     dev: true
 
   /@lumino/coreutils@2.1.2:
     resolution: {integrity: sha512-vyz7WzchTO4HQ8iVAxvSUmb5o/8t3cz1vBo8V4ZIaPGada0Jx0xe3tKQ8bXp4pjHc+AEhMnkCnlUyVYMWbnj4A==}
-
-  /@lumino/disposable@1.10.4:
-    resolution: {integrity: sha512-4ZxyYcyzUS+ZeB2KAH9oAH3w0DUUceiVr+FIZHZ2TAYGWZI/85WlqJtfm0xjwEpCwLLW1TDqJrISuZu3iMmVMA==}
-    dependencies:
-      '@lumino/algorithm': 1.9.2
-      '@lumino/signaling': 1.11.1
-    dev: true
 
   /@lumino/disposable@2.1.2:
     resolution: {integrity: sha512-0qmB6zPt9+uj4SVMTfISn0wUOjYHahtKotwxDD5flfcscj2gsXaFCXO4Oqot1zcsZbg8uJmTUhEzAvFW0QhFNA==}
     dependencies:
       '@lumino/signaling': 2.1.2
 
-  /@lumino/domutils@1.8.2:
-    resolution: {integrity: sha512-QIpMfkPJrs4GrWBuJf2Sn1fpyVPmvqUUAeD8xAQo8+4V5JAT0vUDLxZ9HijefMgNCi3+Bs8Z3lQwRCrz+cFP1A==}
-    dev: true
-
   /@lumino/domutils@2.0.1:
     resolution: {integrity: sha512-tbcfhsdKH04AMjSgYAYGD2xE80YcjrqKnfMTeU2NHt4J294Hzxs1GvEmSMk5qJ3Bbgwx6Z4BbQ7apnFg8Gc6cA==}
-
-  /@lumino/dragdrop@1.14.5(crypto@1.0.1):
-    resolution: {integrity: sha512-LC5xB82+xGF8hFyl716TMpV32OIMIMl+s3RU1PaqDkD6B7PkgiVk6NkJ4X9/GcEvl2igkvlGQt/3L7qxDAJNxw==}
-    dependencies:
-      '@lumino/coreutils': 1.12.1(crypto@1.0.1)
-      '@lumino/disposable': 1.10.4
-    transitivePeerDependencies:
-      - crypto
-    dev: true
 
   /@lumino/dragdrop@2.1.3:
     resolution: {integrity: sha512-lETk7lu+8pMfufxWGL76Dfz8kO/44CgHua0zzaLMh/eK+sRQxghMAxqKAMrEw+6eDy7EsM59R3xuynhkLrxa2A==}
@@ -2160,8 +2062,11 @@ packages:
       '@lumino/coreutils': 2.1.2
       '@lumino/disposable': 2.1.2
 
-  /@lumino/keyboard@1.8.2:
-    resolution: {integrity: sha512-Dy+XqQ1wXbcnuYtjys5A0pAqf4SpAFl9NY6owyIhXAo0Va7w3LYp3jgiP1xAaBAwMuUppiUAfrbjrysZuZ625g==}
+  /@lumino/dragdrop@2.1.4:
+    resolution: {integrity: sha512-/ckaYPHIZC1Ff0pU2H3WDI/Xm7V3i0XnyYG4PeZvG1+ovc0I0zeZtlb6qZXne0Vi2r8L2a0624FjF2CwwgNSnA==}
+    dependencies:
+      '@lumino/coreutils': 2.1.2
+      '@lumino/disposable': 2.1.2
     dev: true
 
   /@lumino/keyboard@2.0.1:
@@ -2186,19 +2091,8 @@ packages:
       '@lumino/disposable': 2.1.2
       '@lumino/signaling': 2.1.2
 
-  /@lumino/properties@1.8.2:
-    resolution: {integrity: sha512-EkjI9Cw8R0U+xC9HxdFSu7X1tz1H1vKu20cGvJ2gU+CXlMB1DvoYJCYxCThByHZ+kURTAap4SE5x8HvKwNPbig==}
-    dev: true
-
   /@lumino/properties@2.0.1:
     resolution: {integrity: sha512-RPtHrp8cQqMnTC915lOIdrmsbPDCC7PhPOZb2YY7/Jj6dEdwmGhoMthc2tBEYWoHP+tU/hVm8UR/mEQby22srQ==}
-
-  /@lumino/signaling@1.11.1:
-    resolution: {integrity: sha512-YCUmgw08VoyMN5KxzqPO3KMx+cwdPv28tAN06C0K7Q/dQf+oufb1XocuhZb5selTrTmmuXeizaYxgLIQGdS1fA==}
-    dependencies:
-      '@lumino/algorithm': 1.9.2
-      '@lumino/properties': 1.8.2
-    dev: true
 
   /@lumino/signaling@2.1.2:
     resolution: {integrity: sha512-KtwKxx+xXkLOX/BdSqtvnsqBTPKDIENFBKeYkMTxstQc3fHRmyTzmaVoeZES+pr1EUy3e8vM4pQFVQpb8VsDdA==}
@@ -2206,34 +2100,10 @@ packages:
       '@lumino/algorithm': 2.0.1
       '@lumino/coreutils': 2.1.2
 
-  /@lumino/virtualdom@1.14.3:
-    resolution: {integrity: sha512-5joUC1yuxeXbpfbSBm/OR8Mu9HoTo6PDX0RKqzlJ9o97iml7zayFN/ynzcxScKGQAo9iaXOY8uVIvGUT8FnsGw==}
-    dependencies:
-      '@lumino/algorithm': 1.9.2
-    dev: true
-
   /@lumino/virtualdom@2.0.1:
     resolution: {integrity: sha512-WNM+uUZX7vORhlDRN9NmhEE04Tz1plDjtbwsX+i/51pQj2N2r7+gsVPY/gR4w+I5apmC3zG8/BojjJYIwi8ogA==}
     dependencies:
       '@lumino/algorithm': 2.0.1
-
-  /@lumino/widgets@1.37.2(crypto@1.0.1):
-    resolution: {integrity: sha512-NHKu1NBDo6ETBDoNrqSkornfUCwc8EFFzw6+LWBfYVxn2PIwciq2SdiJGEyNqL+0h/A9eVKb5ui5z4cwpRekmQ==}
-    dependencies:
-      '@lumino/algorithm': 1.9.2
-      '@lumino/commands': 1.21.1(crypto@1.0.1)
-      '@lumino/coreutils': 1.12.1(crypto@1.0.1)
-      '@lumino/disposable': 1.10.4
-      '@lumino/domutils': 1.8.2
-      '@lumino/dragdrop': 1.14.5(crypto@1.0.1)
-      '@lumino/keyboard': 1.8.2
-      '@lumino/messaging': 1.10.3
-      '@lumino/properties': 1.8.2
-      '@lumino/signaling': 1.11.1
-      '@lumino/virtualdom': 1.14.3
-    transitivePeerDependencies:
-      - crypto
-    dev: true
 
   /@lumino/widgets@2.3.0:
     resolution: {integrity: sha512-82vvNHmi1r5MzLEybq3ImJ7vAkaVxHZyw6/H+3ZlhXYasOwOIlYy7le71VsW8O4EtLLjuf/A/Wme9vsxH7Wp0w==}
@@ -2249,6 +2119,22 @@ packages:
       '@lumino/properties': 2.0.1
       '@lumino/signaling': 2.1.2
       '@lumino/virtualdom': 2.0.1
+
+  /@lumino/widgets@2.3.1:
+    resolution: {integrity: sha512-t3yKoXY4P1K1Tiv7ABZLKjwtn2gFIbaK0jnjFhoHNlzX5q43cm7FjtCFQWrvJbBN6Heq9qq00JPOWXeZ3IlQdg==}
+    dependencies:
+      '@lumino/algorithm': 2.0.1
+      '@lumino/commands': 2.2.0
+      '@lumino/coreutils': 2.1.2
+      '@lumino/disposable': 2.1.2
+      '@lumino/domutils': 2.0.1
+      '@lumino/dragdrop': 2.1.4
+      '@lumino/keyboard': 2.0.1
+      '@lumino/messaging': 2.0.1
+      '@lumino/properties': 2.0.1
+      '@lumino/signaling': 2.1.2
+      '@lumino/virtualdom': 2.0.1
+    dev: true
 
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -2312,22 +2198,6 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@npmcli/fs@1.1.1:
-    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
-    dependencies:
-      '@gar/promisify': 1.1.3
-      semver: 7.5.4
-    dev: true
-
-  /@npmcli/move-file@1.1.2:
-    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
-    engines: {node: '>=10'}
-    deprecated: This functionality has been moved to @npmcli/fs
-    dependencies:
-      mkdirp: 1.0.4
-      rimraf: 3.0.2
-    dev: true
-
   /@pkgr/utils@2.4.2:
     resolution: {integrity: sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -2358,20 +2228,6 @@ packages:
       deepmerge: 4.3.1
       escalade: 3.1.1
     dev: false
-
-  /@rjsf/utils@5.13.0(react@18.2.0):
-    resolution: {integrity: sha512-tG2OuOJUJZ0W7VMZceD0I2SOjfMRRT1tRtG+SKbdNqhtH/gpg40aOMUj9cWgSQnYISEkNZjZq/z7NWln5RxW6A==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      react: ^16.14.0 || >=17
-    dependencies:
-      json-schema-merge-allof: 0.8.1
-      jsonpointer: 5.0.1
-      lodash: 4.17.21
-      lodash-es: 4.17.21
-      react: 18.2.0
-      react-is: 18.2.0
-    dev: true
 
   /@rjsf/utils@5.13.2(react@18.2.0):
     resolution: {integrity: sha512-iluvCOQDwZkp66RRZdIV3TgJnI+I2xv7Ks+UVqjO9lG8U9ygoWuH85zGPAojqapJUuC+frVRZsEBsTwGegDWIw==}
@@ -2857,35 +2713,41 @@ packages:
       '@xtuc/long': 4.2.2
     dev: true
 
-  /@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@5.88.2):
-    resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
+  /@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.88.2):
+    resolution: {integrity: sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==}
+    engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack: 4.x.x || 5.x.x
-      webpack-cli: 4.x.x
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack@5.88.2)
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack@5.88.2)
     dev: true
 
-  /@webpack-cli/info@1.5.0(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
+  /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.88.2):
+    resolution: {integrity: sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==}
+    engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack-cli: 4.x.x
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
     dependencies:
-      envinfo: 7.10.0
-      webpack-cli: 4.10.0(webpack@5.88.2)
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack@5.88.2)
     dev: true
 
-  /@webpack-cli/serve@1.7.0(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
+  /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.88.2):
+    resolution: {integrity: sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==}
+    engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack-cli: 4.x.x
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
       webpack-dev-server: '*'
     peerDependenciesMeta:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0(webpack@5.88.2)
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack@5.88.2)
     dev: true
 
   /@xtuc/ieee754@1.2.0:
@@ -2898,6 +2760,7 @@ packages:
 
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
     dev: true
 
   /acorn-import-assertions@1.9.0(acorn@8.10.0):
@@ -2926,12 +2789,15 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  /aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
+  /ajv-formats@2.1.1(ajv@8.12.0):
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
+      ajv: 8.12.0
     dev: true
 
   /ajv-keywords@3.5.2(ajv@6.12.6):
@@ -2940,6 +2806,15 @@ packages:
       ajv: ^6.9.1
     dependencies:
       ajv: 6.12.6
+    dev: true
+
+  /ajv-keywords@5.1.0(ajv@8.12.0):
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+    dependencies:
+      ajv: 8.12.0
+      fast-deep-equal: 3.1.3
     dev: true
 
   /ajv@6.12.6:
@@ -3179,11 +3054,6 @@ packages:
       - supports-color
       - terser
 
-  /at-least-node@1.0.0:
-    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
-    engines: {node: '>= 4.0.0'}
-    dev: true
-
   /autoprefixer@10.4.15(postcss@8.4.29):
     resolution: {integrity: sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3341,32 +3211,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /cacache@15.3.0:
-    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
-    engines: {node: '>= 10'}
-    dependencies:
-      '@npmcli/fs': 1.1.1
-      '@npmcli/move-file': 1.1.2
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      glob: 7.1.7
-      infer-owner: 1.0.4
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      mkdirp: 1.0.4
-      p-map: 4.0.0
-      promise-inflight: 1.0.1
-      rimraf: 3.0.2
-      ssri: 8.0.1
-      tar: 6.2.0
-      unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
-    dev: true
-
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
@@ -3472,11 +3316,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-    dev: true
-
   /chrome-trace-event@1.0.3:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
     engines: {node: '>=6.0'}
@@ -3489,11 +3328,6 @@ packages:
   /ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
-
-  /clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
-    dev: true
 
   /cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
@@ -3573,6 +3407,11 @@ packages:
   /comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  /commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+    dev: true
+
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
@@ -3582,22 +3421,13 @@ packages:
     engines: {node: '>= 6'}
     dev: false
 
-  /commander@6.0.0:
-    resolution: {integrity: sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA==}
-    engines: {node: '>= 6'}
-    dev: true
-
-  /commander@7.2.0:
-    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
-    engines: {node: '>= 10'}
+  /commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
     dev: true
 
   /common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
-
-  /commondir@1.0.1:
-    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-    dev: true
 
   /compute-gcd@1.2.1:
     resolution: {integrity: sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==}
@@ -3640,28 +3470,27 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  /crypto@1.0.1:
-    resolution: {integrity: sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==}
-    deprecated: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
-    dev: true
-
-  /css-loader@5.2.7(webpack@5.88.2):
-    resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
-    engines: {node: '>= 10.13.0'}
+  /css-loader@6.10.0(webpack@5.88.2):
+    resolution: {integrity: sha512-LTSA/jWbwdMlk+rhmElbDR2vbtQoTBPr7fkJE+mxrHj+7ru0hUmHafDRzWIjIHTwpitWVaqY2/UWGRca3yUgRw==}
+    engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: ^4.27.0 || ^5.0.0
+      '@rspack/core': 0.x || 1.x
+      webpack: ^5.0.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.33)
-      loader-utils: 2.0.4
       postcss: 8.4.33
       postcss-modules-extract-imports: 3.0.0(postcss@8.4.33)
-      postcss-modules-local-by-default: 4.0.3(postcss@8.4.33)
-      postcss-modules-scope: 3.0.0(postcss@8.4.33)
+      postcss-modules-local-by-default: 4.0.4(postcss@8.4.33)
+      postcss-modules-scope: 3.1.1(postcss@8.4.33)
       postcss-modules-values: 4.0.0(postcss@8.4.33)
       postcss-value-parser: 4.2.0
-      schema-utils: 3.3.0
       semver: 7.5.4
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
     dev: true
 
   /css-tree@2.3.1:
@@ -4348,17 +4177,6 @@ packages:
       format: 0.2.2
     dev: false
 
-  /file-loader@6.0.0(webpack@5.88.2):
-    resolution: {integrity: sha512-/aMOAYEFXDdjG0wytpTL5YQLfZnnTmLNjn+AIrJ/6HVnTfDqLsVKUUwkDf4I4kgex36BvjuXEn/TX9B/1ESyqQ==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 2.7.1
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
-    dev: true
-
   /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
@@ -4372,15 +4190,6 @@ packages:
       json5: 2.2.3
       path-exists: 4.0.0
     dev: false
-
-  /find-cache-dir@3.3.2:
-    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
-    engines: {node: '>=8'}
-    dependencies:
-      commondir: 1.0.1
-      make-dir: 3.1.0
-      pkg-dir: 4.2.0
-    dev: true
 
   /find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
@@ -4428,6 +4237,15 @@ packages:
     resolution: {integrity: sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==}
     dev: false
 
+  /fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
   /fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -4444,23 +4262,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
-    dev: true
-
-  /fs-extra@9.1.0:
-    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      at-least-node: 1.0.0
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.0
-    dev: true
-
-  /fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
     dev: true
 
   /fs.realpath@1.0.0:
@@ -4868,18 +4669,9 @@ packages:
   /import-meta-resolve@2.2.2:
     resolution: {integrity: sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==}
 
-  /imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-    dev: true
-
   /indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-    dev: true
-
-  /infer-owner@1.0.4:
-    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
     dev: true
 
   /inflight@1.0.6:
@@ -4904,9 +4696,9 @@ packages:
       side-channel: 1.0.4
     dev: true
 
-  /interpret@2.2.0:
-    resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
-    engines: {node: '>= 0.10'}
+  /interpret@3.1.1:
+    resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
+    engines: {node: '>=10.13.0'}
     dev: true
 
   /is-alphabetical@2.0.1:
@@ -5148,15 +4940,6 @@ packages:
   /isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
-  /jest-worker@26.6.2:
-    resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
-    engines: {node: '>= 10.13.0'}
-    dependencies:
-      '@types/node': 20.10.6
-      merge-stream: 2.0.0
-      supports-color: 7.2.0
-    dev: true
-
   /jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
@@ -5219,13 +5002,6 @@ packages:
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
-  /json5@1.0.2:
-    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
-    hasBin: true
-    dependencies:
-      minimist: 1.2.8
-    dev: true
-
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -5271,14 +5047,6 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  /lib0@0.2.85:
-    resolution: {integrity: sha512-vtAhVttLXCu3ps2OIsTz8CdKYKdcMo7ds1MNBIcSXz6vrY8sxASqpTi4vmsAIn7xjWvyT7haKcWW6woP6jebjQ==}
-    engines: {node: '>=16'}
-    hasBin: true
-    dependencies:
-      isomorphic.js: 0.2.5
-    dev: true
-
   /lib0@0.2.87:
     resolution: {integrity: sha512-TbB63XJixvNToW2IHWAFsCJj9tVnajmwjE14p69i51Rx8byOQd2IP4ourE8v4d7vhyO++nVm1sQk3ePslfbucg==}
     engines: {node: '>=16'}
@@ -5295,7 +5063,7 @@ packages:
         optional: true
     dependencies:
       '@types/webpack-sources': 0.1.9
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
       webpack-sources: 1.4.3
     dev: true
 
@@ -5319,15 +5087,6 @@ packages:
   /loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
-    dev: true
-
-  /loader-utils@1.4.2:
-    resolution: {integrity: sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==}
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      big.js: 5.2.2
-      emojis-list: 3.0.0
-      json5: 1.0.2
     dev: true
 
   /loader-utils@2.0.4:
@@ -5432,13 +5191,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
-
-  /make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
-    dependencies:
-      semver: 6.3.1
     dev: true
 
   /map-obj@1.0.1:
@@ -6020,16 +5772,20 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mini-css-extract-plugin@1.3.9(webpack@5.88.2):
-    resolution: {integrity: sha512-Ac4s+xhVbqlyhXS5J/Vh/QXUz3ycXlCqoCPpg0vdfhsIBH9eg/It/9L1r1XhSCH737M1lqcWnMuWL13zcygn5A==}
-    engines: {node: '>= 10.13.0'}
+  /mini-css-extract-plugin@2.8.0(webpack@5.88.2):
+    resolution: {integrity: sha512-CxmUYPFcTgET1zImteG/LZOy/4T5rTojesQXkSNBiquhydn78tfbCE9sjIjnJ/UcjNjOC1bphTCCW5rrS7cXAg==}
+    engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: ^4.4.0 || ^5.0.0
+      webpack: ^5.0.0
     dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
-      webpack-sources: 1.4.3
+      schema-utils: 4.2.0
+      tapable: 2.2.1
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
+    dev: true
+
+  /mini-svg-data-uri@1.4.4:
+    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
+    hasBin: true
     dev: true
 
   /minimatch@3.1.2:
@@ -6055,56 +5811,9 @@ packages:
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  /minipass-collect@1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: true
-
-  /minipass-flush@1.0.5:
-    resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: true
-
-  /minipass-pipeline@1.2.4:
-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: true
-
-  /minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-    dependencies:
-      yallist: 4.0.0
-    dev: true
-
-  /minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-    dev: true
-
   /mixme@0.5.9:
     resolution: {integrity: sha512-VC5fg6ySUscaWUpI4gxCBTQMH2RdUpNrk+MsbpCYtIvf9SBJdiUey4qE7BXviJsJR4nDQxCZ+3yaYNW3guz/Pw==}
     engines: {node: '>= 8.0.0'}
-    dev: true
-
-  /mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
     dev: true
 
   /mlly@1.4.2:
@@ -6354,13 +6063,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /p-map@4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      aggregate-error: 3.1.0
-    dev: true
-
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
@@ -6542,8 +6244,8 @@ packages:
       postcss: 8.4.33
     dev: true
 
-  /postcss-modules-local-by-default@4.0.3(postcss@8.4.33):
-    resolution: {integrity: sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==}
+  /postcss-modules-local-by-default@4.0.4(postcss@8.4.33):
+    resolution: {integrity: sha512-L4QzMnOdVwRm1Qb8m4x8jsZzKAaPAgrUF1r/hjDR2Xj7R+8Zsf97jAlSQzWtKx5YNiNGN8QxmPFIc/sh+RQl+Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
@@ -6554,8 +6256,8 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-modules-scope@3.0.0(postcss@8.4.33):
-    resolution: {integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==}
+  /postcss-modules-scope@3.1.1(postcss@8.4.33):
+    resolution: {integrity: sha512-uZgqzdTleelWjzJY+Fhti6F3C9iF1JR/dODLs/JDefozYcKTBCdD8BIl6nNPbTbcLnGrk56hzwZC2DaGNvYjzA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
@@ -6668,15 +6370,6 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: true
 
-  /promise-inflight@1.0.1:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dev: true
-
   /prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -6720,17 +6413,6 @@ packages:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
-
-  /raw-loader@4.0.2(webpack@5.88.2):
-    resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
     dev: true
 
   /react-dom@18.2.0(react@18.2.0):
@@ -6800,9 +6482,9 @@ packages:
     dependencies:
       picomatch: 2.3.1
 
-  /rechoir@0.7.1:
-    resolution: {integrity: sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==}
-    engines: {node: '>= 0.10'}
+  /rechoir@0.8.0:
+    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
+    engines: {node: '>= 10.13.0'}
     dependencies:
       resolve: 1.22.8
     dev: true
@@ -7002,13 +6684,6 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    hasBin: true
-    dependencies:
-      glob: 7.1.7
-    dev: true
-
   /rollup@3.29.2:
     resolution: {integrity: sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
@@ -7128,6 +6803,16 @@ packages:
       ajv-keywords: 3.5.2(ajv@6.12.6)
     dev: true
 
+  /schema-utils@4.2.0:
+    resolution: {integrity: sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==}
+    engines: {node: '>= 12.13.0'}
+    dependencies:
+      '@types/json-schema': 7.0.13
+      ajv: 8.12.0
+      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv-keywords: 5.1.0(ajv@8.12.0)
+    dev: true
+
   /search-insights@2.9.0:
     resolution: {integrity: sha512-bkWW9nIHOFkLwjQ1xqVaMbjjO5vhP26ERsH9Y3pKr8imthofEFIxlnOabkmGcw6ksRj9jWidcI65vvjJH/nTGg==}
     dev: false
@@ -7154,12 +6839,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-
-  /serialize-javascript@5.0.1:
-    resolution: {integrity: sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==}
-    dependencies:
-      randombytes: 2.1.0
-    dev: true
 
   /serialize-javascript@6.0.1:
     resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
@@ -7302,7 +6981,7 @@ packages:
       loader-utils: 2.0.4
       schema-utils: 2.7.1
       source-map: 0.6.1
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
     dev: true
 
   /source-map-support@0.5.21:
@@ -7356,13 +7035,6 @@ packages:
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
-  /ssri@8.0.1:
-    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: true
 
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -7485,15 +7157,13 @@ packages:
       acorn: 8.10.0
     dev: true
 
-  /style-loader@2.0.0(webpack@5.88.2):
-    resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
-    engines: {node: '>= 10.13.0'}
+  /style-loader@3.3.4(webpack@5.88.2):
+    resolution: {integrity: sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==}
+    engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: ^5.0.0
     dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
     dev: true
 
   /style-to-object@0.4.2:
@@ -7564,16 +7234,6 @@ packages:
       periscopic: 3.1.0
     dev: true
 
-  /svg-url-loader@6.0.0(webpack@5.88.2):
-    resolution: {integrity: sha512-Qr5SCKxyxKcRnvnVrO3iQj9EX/v40UiGEMshgegzV7vpo3yc+HexELOdtWcA3MKjL8IyZZ1zOdcILmDEa/8JJQ==}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      file-loader: 6.0.0(webpack@5.88.2)
-      loader-utils: 2.0.4
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
-    dev: true
-
   /synckit@0.8.5:
     resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -7617,41 +7277,9 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /tar@6.2.0:
-    resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-    dev: true
-
   /term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
-    dev: true
-
-  /terser-webpack-plugin@4.2.3(webpack@5.88.2):
-    resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      cacache: 15.3.0
-      find-cache-dir: 3.3.2
-      jest-worker: 26.6.2
-      p-limit: 3.1.0
-      schema-utils: 3.3.0
-      serialize-javascript: 5.0.1
-      source-map: 0.6.1
-      terser: 5.19.4
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
-      webpack-sources: 1.4.3
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /terser-webpack-plugin@5.3.9(esbuild@0.20.0)(webpack@5.88.2):
@@ -7676,7 +7304,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.4
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
     dev: true
 
   /terser@5.19.4:
@@ -7737,12 +7365,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-
-  /to-string-loader@1.2.0:
-    resolution: {integrity: sha512-KsWUL8FccgBW9FPFm4vYoQbOOcO5m6hKOGYoXjbseD9/4Ft+ravXN5jolQ9kTKYcK4zPt1j+khx97GPGnVoi6A==}
-    dependencies:
-      loader-utils: 1.4.2
-    dev: true
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -7907,18 +7529,6 @@ packages:
       trough: 2.1.0
       vfile: 5.3.7
 
-  /unique-filename@1.1.1:
-    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
-    dependencies:
-      unique-slug: 2.0.2
-    dev: true
-
-  /unique-slug@2.0.2:
-    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
-    dependencies:
-      imurmurhash: 0.1.4
-    dev: true
-
   /unist-util-generated@2.0.1:
     resolution: {integrity: sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==}
 
@@ -8002,23 +7612,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
-
-  /url-loader@4.1.1(file-loader@6.0.0)(webpack@5.88.2):
-    resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      file-loader: '*'
-      webpack: ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      file-loader:
-        optional: true
-    dependencies:
-      file-loader: 6.0.0(webpack@5.88.2)
-      loader-utils: 2.0.4
-      mime-types: 2.1.35
-      schema-utils: 3.3.0
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
-    dev: true
 
   /url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -8360,20 +7953,17 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /webpack-cli@4.10.0(webpack@5.88.2):
-    resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
-    engines: {node: '>=10.13.0'}
+  /webpack-cli@5.1.4(webpack@5.88.2):
+    resolution: {integrity: sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==}
+    engines: {node: '>=14.15.0'}
     hasBin: true
     peerDependencies:
       '@webpack-cli/generators': '*'
-      '@webpack-cli/migrate': '*'
-      webpack: 4.x.x || 5.x.x
+      webpack: 5.x.x
       webpack-bundle-analyzer: '*'
       webpack-dev-server: '*'
     peerDependenciesMeta:
       '@webpack-cli/generators':
-        optional: true
-      '@webpack-cli/migrate':
         optional: true
       webpack-bundle-analyzer:
         optional: true
@@ -8381,17 +7971,18 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.88.2)
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.88.2)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.88.2)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.88.2)
       colorette: 2.0.20
-      commander: 7.2.0
+      commander: 10.0.1
       cross-spawn: 7.0.3
+      envinfo: 7.10.0
       fastest-levenshtein: 1.0.16
       import-local: 3.1.0
-      interpret: 2.2.0
-      rechoir: 0.7.1
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
+      interpret: 3.1.1
+      rechoir: 0.8.0
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
       webpack-merge: 5.9.0
     dev: true
 
@@ -8415,7 +8006,7 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /webpack@5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0):
+  /webpack@5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -8448,7 +8039,7 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.9(esbuild@0.20.0)(webpack@5.88.2)
       watchpack: 2.4.0
-      webpack-cli: 4.10.0(webpack@5.88.2)
+      webpack-cli: 5.1.4(webpack@5.88.2)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -8565,7 +8156,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.20.0)(webpack-cli@5.1.4)
     dev: true
 
   /wrap-ansi@6.2.0:
@@ -8597,19 +8188,6 @@ packages:
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  /ws@8.14.1:
-    resolution: {integrity: sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: true
-
   /ws@8.14.2:
     resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
     engines: {node: '>=10.0.0'}
@@ -8621,12 +8199,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  /y-protocols@1.0.5:
-    resolution: {integrity: sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==}
-    dependencies:
-      lib0: 0.2.85
-    dev: true
 
   /y-protocols@1.0.6(yjs@13.6.8):
     resolution: {integrity: sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==}
@@ -8701,13 +8273,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: true
-
-  /yjs@13.6.7:
-    resolution: {integrity: sha512-mCZTh4kjvUS2DnaktsYN6wLH3WZCJBLqrTdkWh1bIDpA/sB/GNFaLA/dyVJj2Hc7KwONuuoC/vWe9bwBBosZLQ==}
-    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
-    dependencies:
-      lib0: 0.2.85
     dev: true
 
   /yjs@13.6.8:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "jupyterlab==3.*"]
+requires = ["hatchling", "jupyterlab"]
 build-backend = "hatchling.build"
 
 [project]
@@ -11,10 +11,9 @@ authors = [
 license = { text = "MIT" }
 dynamic = ["version"]
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "ipywidgets>=7.6.0",
-    "importlib-metadata; python_version < '3.8'",
     "typing-extensions>=4.2.0",
     "psygnal>=0.8.1",
 ]
@@ -25,7 +24,7 @@ test = [
     "pytest",
     "pytest-cov",
     "ruff",
-    "msgspec; python_version > '3.7'",
+    "msgspec",
     "ipython<8.13; python_version < '3.9'",
 ]
 dev = [
@@ -75,7 +74,6 @@ pattern = "\"version\": \"(?P<version>.+?)\""
 
 [tool.hatch.envs.default]
 features = ["test", "dev"]
-python = "3.11"
 
 [tool.hatch.envs.default.scripts]
 lint = [
@@ -91,9 +89,11 @@ test = "pytest . --cov anywidget --cov-report term-missing"
 # https://github.com/charliermarsh/ruff
 [tool.ruff]
 line-length = 88
-target-version = "py37"
+target-version = "py38"
 src = ["anywidget", "tests"]
 exclude = ["packages"]
+
+[tool.ruff.lint]
 extend-select = [
     "E",    # style errors
     "F",    # flakes
@@ -120,7 +120,7 @@ extend-ignore = [
     "E501", # Line too long (delegate to `ruff format`)
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["D", "S101"]
 "docs/*.py" = ["D"]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,7 +80,7 @@ def test_enables_widget_manager_in_colab(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setitem(sys.modules, "google.colab.output", mock)
     get_repr_metadata()
     get_repr_metadata()
-    assert mock.enable_custom_widget_manager.assert_called_once
+    mock.enable_custom_widget_manager.assert_called_once()
 
 
 def test_get_metadata(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -129,16 +129,20 @@ def test_patched_repr_ipywidget_v8(monkeypatch: pytest.MonkeyPatch):
     assert bundle[0] and _WIDGET_MIME_TYPE in bundle[0]
     assert bundle[1] == {}
 
+
+def test_patched_repr_ipywidget_v8_colab(monkeypatch: pytest.MonkeyPatch):
     mock = MagicMock()
-    mock._installed_url = "foo"
+    mock._widgets._installed_url = "foo"
     monkeypatch.setitem(sys.modules, "google.colab.output", mock)
 
     w = anywidget.AnyWidget()
-    assert mock.enable_custom_widget_manager.assert_called_once
-
     bundle = w._repr_mimebundle_()
     assert bundle[0] and _WIDGET_MIME_TYPE in bundle[0]
-    assert _WIDGET_MIME_TYPE in bundle[1]
+    assert bundle[1] == {
+        _WIDGET_MIME_TYPE: {
+            "colab": {"custom_widget_manager": {"url": mock._widgets._installed_url}},
+        }
+    }
 
 
 def test_infer_file_contents(tmp_path: pathlib.Path):


### PR DESCRIPTION
Related 
- https://github.com/manzt/anywidget/pull/161
- https://github.com/manzt/anywidget/issues/166
- https://github.com/manzt/anywidget/pull/167

We've tried to keep backward compatibility with Python 3.7, but now it is getting in the way of supporting 3.12. Python 3.7 has been EOL for almost a year, and many others in the ecosystem have moved on (including JupyterLab). If we were able, I'd try to keep support but it's causing too many issues with latest version of Python.

Let me explain. Custom Jupyter Widgets (which anywidget is internally) requires building with JupyterLab (via `@jupyterlab/builder`). In order to build a custom widget, and hence anywidget from scratch the build system must run:

```sh
jupyter labextension build
# - Requires JupyterLab
#    - Requires `@jupyterlab/builder`
```

The version of JLab (Python) and `@jupyterlab/builder` are tied deeply tied together. This is a problem. It has meant that in order to keep support for Python 3.7, we've needed to keep our build system on JupyterLab 3 and an older version of `@jupyterlab/builder`, since JupyterLab 4 has dropped support for Python 3.7. This older version of JupyterLab does not work on Python 3.12 (issue with pyzmq), which means that you need to have two different versions of Python to build and run anywidget (**bad**).

anywidget's philosophy is to be low friction, while pushing the ecosystem forward. If we were able to move off of JupyterLab as a build system dep, it may be possible to support this legacy use case, but this doesn't not seem possible without extreme build-tooling hell.

Ecosystem:

- Python 3.7 is EOL
- Google Colab is Python 3.10
- JupyterLab 4 has dropped support for Python 3.7
- `ipywidgets` pyproject.toml says 3.7 support, but [tests are only run on >=3.8](https://github.com/jupyter-widgets/ipywidgets/blob/b78de43e12ff26e4aa16e6e4c6844a7c82a8ee1c/.github/workflows/tests.yml#L80)