### PR TITLE
chore: Try out `macos-14` M1 test runners available for open-source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   LintPython:
     name: Python / Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       # this could be replaced with pre-commit.ci
@@ -19,7 +19,7 @@ jobs:
 
   TestPython:
     name: Python / Test
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
@@ -47,7 +47,7 @@ jobs:
 
   LintJavaScript:
     name: JavaScript / Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
@@ -60,7 +60,7 @@ jobs:
 
   TypecheckJavaScript:
     name: JavaScript / Typecheck
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
@@ -73,7 +73,7 @@ jobs:
 
   TestJavaScript:
     name: JavaScript / Test
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      # this could be replaced with pre-commit.ci
-      - run: pipx run pre-commit run --all-files
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files
 
   TestPython:
     name: Python / Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
   TestPython:
     name: Python / Test
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
