### PR TITLE
feat: Add AnyWidget type

### DIFF
--- a/.changeset/flat-donuts-rule.md
+++ b/.changeset/flat-donuts-rule.md
@@ -1,0 +1,5 @@
+---
+"@anywidget/types": patch
+---
+
+Add `AnyWidget` definition

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -16,13 +16,12 @@ npm install @anywidget/types
  * @prop {number} value - the current count
  */
 
+/** @type {import("@anywidget/types").AnyWidget<Model>} */
 export default {
-	/** @type {import("@anywidget/types").Initialize<Model>} */
 	initialize({ model }) {
 		let value = model.get("value");
 		//^? number
 	},
-	/** @type {import("@anywidget/types").Render<Model>} */
 	render({ model, el }) {
 		let value = model.get("value");
 		//^? number

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -59,3 +59,12 @@ export interface InitializeProps<T extends ObjectHash = ObjectHash> {
 export interface Initialize<T extends ObjectHash = ObjectHash> {
 	(props: InitializeProps<T>): Awaitable<void | (() => Awaitable<void>)>;
 }
+
+interface WidgetDef<T extends ObjectHash = ObjectHash> {
+	initialize?: Initialize<T>;
+	render?: Render<T>;
+}
+
+export type AnyWidget<T extends ObjectHash = ObjectHash> =
+	| WidgetDef<T>
+	| (() => Awaitable<WidgetDef<T>>);


### PR DESCRIPTION
Adds a single type for a default export. The types of `initialize` and `render` are automatically inferred.

```js
/**
 * @typedef Model
 * @prop {number} value - the current count
 */

/** @type {import("@anywidget/types").AnyWidget<Model>} */
export default {
  initialize({ model }) {
    let value = model.get("value");
      //^? number
  },
  render({ model, el }) {
    let value = model.get("value");
      //^? number

    model.get("nope");
    // type error, `nope` is not defined on Model

    model.set("value", "not a number");
                      //^? type error, must be a number
  },
};
```
