### PR TITLE
feat(create-anywidget): Add `autoreload` extension to demo notebook

### DIFF
--- a/.changeset/hot-dolphins-grab.md
+++ b/.changeset/hot-dolphins-grab.md
@@ -1,0 +1,5 @@
+---
+"create-anywidget": patch
+---
+
+Add `autoreload` extension to demo notebook

--- a/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
@@ -44,6 +44,8 @@ in the notebook.
 			"metadata": {},
 			"outputs": [],
 			"source": [
+				"%load_ext autoreload\\n",
+				"%autoreload 2\\n",
 				"%env ANYWIDGET_HMR=1"
 			]
 		},
@@ -248,6 +250,8 @@ in the notebook.
 			"metadata": {},
 			"outputs": [],
 			"source": [
+				"%load_ext autoreload\\n",
+				"%autoreload 2\\n",
 				"%env ANYWIDGET_HMR=1"
 			]
 		},
@@ -484,6 +488,8 @@ in the notebook.
 			"metadata": {},
 			"outputs": [],
 			"source": [
+				"%load_ext autoreload\\n",
+				"%autoreload 2\\n",
 				"%env ANYWIDGET_HMR=1"
 			]
 		},
@@ -677,6 +683,8 @@ in the notebook.
 			"metadata": {},
 			"outputs": [],
 			"source": [
+				"%load_ext autoreload\\n",
+				"%autoreload 2\\n",
 				"%env ANYWIDGET_HMR=1"
 			]
 		},
@@ -878,6 +886,8 @@ in the notebook.
 			"metadata": {},
 			"outputs": [],
 			"source": [
+				"%load_ext autoreload\\n",
+				"%autoreload 2\\n",
 				"%env ANYWIDGET_HMR=1"
 			]
 		},
@@ -1116,6 +1126,8 @@ in the notebook.
 			"metadata": {},
 			"outputs": [],
 			"source": [
+				"%load_ext autoreload\\n",
+				"%autoreload 2\\n",
 				"%env ANYWIDGET_HMR=1"
 			]
 		},
@@ -1320,6 +1332,8 @@ in the notebook.
 			"metadata": {},
 			"outputs": [],
 			"source": [
+				"%load_ext autoreload\\n",
+				"%autoreload 2\\n",
 				"%env ANYWIDGET_HMR=1"
 			]
 		},
@@ -1556,6 +1570,8 @@ in the notebook.
 			"metadata": {},
 			"outputs": [],
 			"source": [
+				"%load_ext autoreload\\n",
+				"%autoreload 2\\n",
 				"%env ANYWIDGET_HMR=1"
 			]
 		},
@@ -1749,6 +1765,8 @@ in the notebook.
 			"metadata": {},
 			"outputs": [],
 			"source": [
+				"%load_ext autoreload\\n",
+				"%autoreload 2\\n",
 				"%env ANYWIDGET_HMR=1"
 			]
 		},
@@ -1950,6 +1968,8 @@ in the notebook.
 			"metadata": {},
 			"outputs": [],
 			"source": [
+				"%load_ext autoreload\\n",
+				"%autoreload 2\\n",
 				"%env ANYWIDGET_HMR=1"
 			]
 		},

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -202,7 +202,11 @@ let notebook = (name) =>
 				"execution_count": null,
 				"metadata": {},
 				"outputs": [],
-				"source": ["%env ANYWIDGET_HMR=1"],
+				"source": [
+					"%load_ext autoreload\n",
+					"%autoreload 2\n",
+					"%env ANYWIDGET_HMR=1"
+				],
 			},
 			{
 				"cell_type": "code",

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -205,7 +205,7 @@ let notebook = (name) =>
 				"source": [
 					"%load_ext autoreload\n",
 					"%autoreload 2\n",
-					"%env ANYWIDGET_HMR=1"
+					"%env ANYWIDGET_HMR=1",
 				],
 			},
 			{


### PR DESCRIPTION
I can never remember the [`autoreload`](https://ipython.readthedocs.io/en/stable/config/extensions/autoreload.html) extension, which seems like it would be nice to include by default in the demo notebook. This way you can edit the Python code without needing to restart the kernel.
