### PR TITLE
fix(docs): Fix typo in vite config

### DIFF
--- a/docs/src/pages/en/bundling.md
+++ b/docs/src/pages/en/bundling.md
@@ -218,7 +218,7 @@ export default defineConfig({
       formats: ["es"],
     },
   },
-+  plugin: [anywidget()],
++  plugins: [anywidget()],
 });
 ```
 


### PR DESCRIPTION
Small typo, `plugin` -> `plugins`: https://vitejs.dev/config/shared-options.html#plugins