### PR TITLE
Allow semver-compatible frontend versions

### DIFF
--- a/.changeset/cuddly-fishes-heal.md
+++ b/.changeset/cuddly-fishes-heal.md
@@ -1,0 +1,7 @@
+---
+"anywidget": patch
+---
+
+Relax version pinning for anywidget front end
+
+Adopted `~major.minor.*` notation for more flexible version compatibility in the front end, mirroring practices improve compatability in environments where bumping the front-end versions is not possible for end users (i.e., JupyterHub). This change is intended to enhance adaptability without causing disruptions. If issues arise, please report them on our issues page.

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -83,7 +83,7 @@ def get_semver_version(version: str):
     if is_pre_release:
         return ".".join(split)
 
-    return "~" + ".".join([split[0], split[1], "0"])
+    return "~" + ".".join([split[0], split[1], "*"])
 
 
 _ANYWIDGET_SEMVER_VERSION = get_semver_version(__version__)

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -75,13 +75,26 @@ _TARGET_NAME = "jupyter.widget"
 _ANYWIDGET_MODEL_NAME = "AnyModel"
 _ANYWIDGET_VIEW_NAME = "AnyView"
 _ANYWIDGET_JS_MODULE = "anywidget"
+
+
+def get_semver_version(version: str):
+    split = version.split(".", maxsplit=2)
+    is_pre_release = "a" in split[2] or "b" in split[2]
+    if is_pre_release:
+        return ".".join(split)
+
+    return "~" + ".".join([split[0], split[1], "0"])
+
+
+_ANYWIDGET_SEMVER_VERSION = get_semver_version(__version__)
+
 _ANYWIDGET_STATE = {
     "_model_module": _ANYWIDGET_JS_MODULE,
     "_model_name": _ANYWIDGET_MODEL_NAME,
-    "_model_module_version": __version__,
+    "_model_module_version": _ANYWIDGET_SEMVER_VERSION,
     "_view_module": _ANYWIDGET_JS_MODULE,
     "_view_name": _ANYWIDGET_VIEW_NAME,
-    "_view_module_version": __version__,
+    "_view_module_version": _ANYWIDGET_SEMVER_VERSION,
     "_view_count": None,
 }
 
@@ -368,7 +381,7 @@ class ReprMimeBundle:
         state, buffer_paths, buffers = remove_buffers(state)
         if getattr(self._comm, "kernel", None):
             msg = {"method": "update", "state": state, "buffer_paths": buffer_paths}
-            self._comm.send(data=msg, buffers=buffers) # type: ignore
+            self._comm.send(data=msg, buffers=buffers)  # type: ignore
 
     def _handle_msg(self, msg: CommMessage) -> None:
         """Called when a msg is received from the front-end.
@@ -437,7 +450,7 @@ class ReprMimeBundle:
         """
         if js_to_py:
             # connect changes in the view to the instance
-            self._comm.on_msg(self._handle_msg) # type: ignore
+            self._comm.on_msg(self._handle_msg)  # type: ignore
             self.send_state()
 
         if py_to_js and self._autodetect_observer:

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -44,7 +44,7 @@ from ._util import (
     repr_mimebundle,
     try_file_contents,
 )
-from ._version import __version__
+from ._version import _ANYWIDGET_SEMVER_VERSION
 
 if TYPE_CHECKING:  # pragma: no cover
     import comm
@@ -72,18 +72,6 @@ _TARGET_NAME = "jupyter.widget"
 _ANYWIDGET_MODEL_NAME = "AnyModel"
 _ANYWIDGET_VIEW_NAME = "AnyView"
 _ANYWIDGET_JS_MODULE = "anywidget"
-
-
-def get_semver_version(version: str):
-    split = version.split(".", maxsplit=2)
-    is_pre_release = "a" in split[2] or "b" in split[2]
-    if is_pre_release:
-        return ".".join(split)
-
-    return "~" + ".".join([split[0], split[1], "*"])
-
-
-_ANYWIDGET_SEMVER_VERSION = get_semver_version(__version__)
 
 _ANYWIDGET_STATE = {
     "_model_module": _ANYWIDGET_JS_MODULE,

--- a/anywidget/_version.py
+++ b/anywidget/_version.py
@@ -12,7 +12,7 @@ except PackageNotFoundError:
     __version__ = "uninstalled"
 
 
-def get_semver_version(version: str):
+def get_semver_version(version: str) -> str:
     split = version.split(".", maxsplit=2)
     is_pre_release = "a" in split[2] or "b" in split[2]
     if is_pre_release:

--- a/anywidget/_version.py
+++ b/anywidget/_version.py
@@ -10,3 +10,15 @@ try:
     __version__ = version("anywidget")
 except PackageNotFoundError:
     __version__ = "uninstalled"
+
+
+def get_semver_version(version: str):
+    split = version.split(".", maxsplit=2)
+    is_pre_release = "a" in split[2] or "b" in split[2]
+    if is_pre_release:
+        return ".".join(split)
+
+    return "~" + ".".join([split[0], split[1], "*"])
+
+
+_ANYWIDGET_SEMVER_VERSION = get_semver_version(__version__)

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -17,7 +17,7 @@ from ._util import (
     repr_mimebundle,
     try_file_contents,
 )
-from ._version import __version__
+from ._version import _ANYWIDGET_SEMVER_VERSION
 from .experimental import _collect_anywidget_commands, _register_anywidget_commands
 
 
@@ -26,11 +26,11 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
 
     _model_name = t.Unicode("AnyModel").tag(sync=True)
     _model_module = t.Unicode("anywidget").tag(sync=True)
-    _model_module_version = t.Unicode(__version__).tag(sync=True)
+    _model_module_version = t.Unicode(_ANYWIDGET_SEMVER_VERSION).tag(sync=True)
 
     _view_name = t.Unicode("AnyView").tag(sync=True)
     _view_module = t.Unicode("anywidget").tag(sync=True)
-    _view_module_version = t.Unicode(__version__).tag(sync=True)
+    _view_module_version = t.Unicode(_ANYWIDGET_SEMVER_VERSION).tag(sync=True)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if in_colab():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from anywidget._util import (
     remove_buffers,
     try_file_contents,
 )
+from anywidget._version import get_semver_version
 
 
 def enable_hmr():
@@ -163,3 +164,22 @@ def test_try_file_contents_warns(
 
         assert isinstance(file_contents, FileContents)
         assert file_contents._background_thread is None
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        ("1.0.0", "~1.0.*"),
+        ("2.1.1", "~2.1.*"),
+        ("0.0.1", "~0.0.*"),
+        ("1.2.3a", "1.2.3a"),
+        ("4.5.6b", "4.5.6b"),
+        ("1.0.0-alpha", "1.0.0-alpha"),
+        ("2.1.1-beta", "2.1.1-beta"),
+        ("3.2.1-alpha.1", "3.2.1-alpha.1"),
+        ("0.0.1-beta.2", "0.0.1-beta.2"),
+        ("1.2.3-rc.4", "~1.2.*"),
+    ],
+)
+def test_get_semver_version(version, expected):
+    assert get_semver_version(version) == expected


### PR DESCRIPTION
In relation to the discussion about JupyterHub in https://github.com/manzt/anywidget/issues/385, I've suggested to a few of my users to install anywidget on the server, then install lonboard in the client environment. Lonboard does not pin a version of anywidget, so when a new anywidget version is released, the next install of lonboard will break because the client anywidget version does not exactly match the server anywidget version.

I have reason to believe that using `"~major.minor.*"` works, because pydeck has been doing that for its frontend code for a while, to allow the Python code and JS bindings to be versioned separately (see [1](https://github.com/visgl/deck.gl/blob/9117414ef894b8755e0eff33e7cf503a2137249f/bindings/pydeck/pydeck/frontend_semver.py#L1), [2](https://github.com/visgl/deck.gl/blob/ff7566644bc716cf917c0f21e8155b5ff1074b7a/bindings/pydeck/pydeck/widget/_frontend.py#L14), [3](https://github.com/visgl/deck.gl/blob/9117414ef894b8755e0eff33e7cf503a2137249f/bindings/pydeck/pydeck/widget/widget.py#L55)). 

That said, I haven't yet tested this in a JupyterHub environment. (I haven't tried to set up the development environment yet)