### PR TITLE
feat(anywidget): Suppress errors when inspecting for RPC commands

### DIFF
--- a/.changeset/pink-impalas-cheat.md
+++ b/.changeset/pink-impalas-cheat.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+feat: Suppress errors when inspecting widget for commands

--- a/anywidget/experimental.py
+++ b/anywidget/experimental.py
@@ -133,7 +133,7 @@ def _collect_commands(widget: WidgetBase) -> dict[str, _AnyWidgetCommandBound]:
     for attr_name in dir(widget):
         # suppressing silly assertion erro from ipywidgets _staticproperty
         # ref: https://github.com/jupyter-widgets/ipywidgets/blob/b78de43e12ff26e4aa16e6e4c6844a7c82a8ee1c/python/ipywidgets/ipywidgets/widgets/widget.py#L291-L297
-        with contextlib.suppress(AssertionError):
+        with contextlib.suppress(Exception):
             attr = getattr(widget, attr_name)
             if callable(attr) and getattr(attr, _ANYWIDGET_COMMAND, False):
                 cmds[attr_name] = attr

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -306,3 +306,29 @@ def test_anywidget_commands_register_one_callback():
 
     w = Widget()
     assert len(w._msg_callbacks.callbacks) == 1
+
+
+def test_supresses_error_in_constructor():
+    import anywidget.experimental
+
+    class Widget(anywidget.AnyWidget):
+        _esm = """
+        export default {
+            async render({ model, el, experimental }) {
+                let [msg] = await experimental.invoke("_echo", "hi");
+            }
+        }
+        """
+
+        @anywidget.experimental.command
+        def _echo(
+            self, msg: typing.Any, buffers: list[bytes]
+        ) -> tuple[str, list[bytes]]:
+            return msg, buffers
+
+        @property
+        def value(self):
+            raise ValueError("error")
+
+    w = Widget()
+    assert len(w._msg_callbacks.callbacks) == 1


### PR DESCRIPTION
Properties can have unexpected behaviors (if fields are not set). This PR just suppresses exceptions when inspecting for RPC commands.

Suppresses error coming up in jupyter-scatter: https://github.com/flekschas/jupyter-scatter/issues/115. It uncovered a bug in JupyterScatter, but I think we shouldn't just fail if there is a weird property.