### PR TITLE
Refactor AnyWidget command registration

### DIFF
--- a/.changeset/ten-apricots-float.md
+++ b/.changeset/ten-apricots-float.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+Refactor AnyWidget command registration

--- a/anywidget/experimental.py
+++ b/anywidget/experimental.py
@@ -144,7 +144,7 @@ def _register_anywidget_commands(widget: WidgetBase) -> None:
     """Register a custom message reducer for a widget if it implements the protocol."""
     # Only add the callback if the widget has any commands.
     cmds = typing.cast(
-        dict[str, _AnyWidgetCommandBound],
+        'dict[str, _AnyWidgetCommandBound]',
         getattr(type(widget), _ANYWIDGET_COMMANDS, {}),
     )
     if not cmds:

--- a/anywidget/experimental.py
+++ b/anywidget/experimental.py
@@ -144,7 +144,7 @@ def _register_anywidget_commands(widget: WidgetBase) -> None:
     """Register a custom message reducer for a widget if it implements the protocol."""
     # Only add the callback if the widget has any commands.
     cmds = typing.cast(
-        'dict[str, _AnyWidgetCommandBound]',
+        "dict[str, _AnyWidgetCommandBound]",
         getattr(type(widget), _ANYWIDGET_COMMANDS, {}),
     )
     if not cmds:

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -17,7 +17,7 @@ from ._util import (
     try_file_contents,
 )
 from ._version import __version__
-from .experimental import _register_anywidget_commands, _collect_anywidget_commands
+from .experimental import _collect_anywidget_commands, _register_anywidget_commands
 
 
 class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -17,7 +17,7 @@ from ._util import (
     try_file_contents,
 )
 from ._version import __version__
-from .experimental import _register_anywidget_commands
+from .experimental import _register_anywidget_commands, _collect_anywidget_commands
 
 
 class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
@@ -68,6 +68,7 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
             file_contents = try_file_contents(getattr(cls, key))
             if file_contents:
                 setattr(cls, key, file_contents)
+        _collect_anywidget_commands(cls)
 
     if hasattr(ipywidgets.DOMWidget, "_repr_mimebundle_"):
         # ipywidgets v8


### PR DESCRIPTION
separates the collection and registration of anywidget commands.  `_collect_anywidget_commands` happens on `__init_subclass__` ... and doesn't require getting any attributes on widget instances.  while `_register_anywidget_commands` still happens on widget init.

just an option. not necessarily much better :)