### PR TITLE
docs: cleanup after requestAnimationFrame example

### DIFF
--- a/docs/src/pages/blog/anywidget-02.md
+++ b/docs/src/pages/blog/anywidget-02.md
@@ -219,28 +219,19 @@ Another common scenario requiring proper cleanup is when using
 `requestAnimationFrame` to continually redraw into a canvas:
 
 ```javascript
-class MyCustomRenderer {
-	constructor() {
-		this.render = this.render.bind(this);
-		this.redrawRequest = requestAnimationFrame(this.render);
-		this.canvasEl = document.createElement("canvas");
-	}
-
-	render() {
-		this.redrawRequest = requestAnimationFrame(this.render);
-
-		// ...custom rendering goes here...
-	}
-}
-
 export default {
 	render({ model, el }) {
-		const renderer = new MyCustomRenderer();
-
-		el.appendChild(renderer.canvasEl);
+		const canvasEl = document.createElement("canvas");
+		let requestId = requestAnimationFrame(step);
+		
+		function step() {
+			/* ...custom rendering goes here... */
+			requestId = requestAnimationFrame(step);
+		}
+		el.appendChild(canvasEl);
 
 		return () => {
-			cancelAnimationFrame(renderer.redrawRequest);
+			cancelAnimationFrame(requestId);
 		};
 	},
 };

--- a/docs/src/pages/blog/anywidget-02.md
+++ b/docs/src/pages/blog/anywidget-02.md
@@ -215,6 +215,40 @@ export default { render };
 > Note: The above front-end code requires transformation with tool like
 > `esbuild` to allow for the special JSX syntax (e.g., `<App />`).
 
+Another common scenario requiring proper cleanup is when using
+`requestAnimationFrame` to continually redraw into a canvas:
+
+```javascript
+class MyCustomRenderer {
+	constructor() {
+		this.render = this.render.bind(this);
+		this.redrawRequest = requestAnimationFrame(this.render);
+		this.canvasEl = document.createElement("canvas");
+	}
+
+	render() {
+		this.redrawRequest = requestAnimationFrame(this.render);
+
+		// ...custom rendering goes here...
+	}
+}
+
+export default {
+	render({ model, el }) {
+		const renderer = new MyCustomRenderer();
+
+		el.appendChild(renderer.canvasEl);
+
+		return () => {
+			cancelAnimationFrame(renderer.redrawRequest);
+		};
+	},
+};
+```
+
+This prevents the accumulation of several animation loops executing at the same
+time after re-running the cell a bunch of times.
+
 ## Getting Started
 
 To start using **anywidget** v0.2, upgrade your package using pip:

--- a/docs/src/pages/blog/anywidget-02.md
+++ b/docs/src/pages/blog/anywidget-02.md
@@ -223,7 +223,7 @@ export default {
 	render({ model, el }) {
 		const canvasEl = document.createElement("canvas");
 		let requestId = requestAnimationFrame(step);
-		
+
 		function step() {
 			/* ...custom rendering goes here... */
 			requestId = requestAnimationFrame(step);


### PR DESCRIPTION
Quick sketch of the scenario where you use the cleanup function returned from `render()` to call `cancelAnimationFrame` to break the continuously updating frameloop.

I still want to think about whether this is the most minimal and expressive code example (that's why I'm keeping it a draft). There also might be a better way to word the description.