### PR TITLE
fix(experimental): Ensure `command` is called with `self`

### DIFF
--- a/.changeset/empty-walls-know.md
+++ b/.changeset/empty-walls-know.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+Ensure anywidget.experimental.command is called with self

--- a/anywidget/experimental.py
+++ b/anywidget/experimental.py
@@ -123,13 +123,8 @@ def command(cmd: _AnyWidgetCommand) -> _AnyWidgetCommand:
     return cmd
 
 
-_AnyWidgetCommandBound = typing.Callable[
-    [typing.Any, typing.List[bytes]], typing.Tuple[typing.Any, typing.List[bytes]]
-]
-
-
 def _collect_anywidget_commands(widget_cls: type) -> None:
-    cmds: dict[str, _AnyWidgetCommandBound] = {}
+    cmds: dict[str, _AnyWidgetCommand] = {}
     for base in widget_cls.__mro__:
         if not hasattr(base, "__dict__"):
             continue
@@ -144,7 +139,7 @@ def _register_anywidget_commands(widget: WidgetBase) -> None:
     """Register a custom message reducer for a widget if it implements the protocol."""
     # Only add the callback if the widget has any commands.
     cmds = typing.cast(
-        "dict[str, _AnyWidgetCommandBound]",
+        "dict[str, _AnyWidgetCommand]",
         getattr(type(widget), _ANYWIDGET_COMMANDS, {}),
     )
     if not cmds:
@@ -156,7 +151,7 @@ def _register_anywidget_commands(widget: WidgetBase) -> None:
         if not isinstance(msg, dict) or msg.get("kind") != "anywidget-command":
             return
         cmd = cmds[msg["name"]]
-        response, buffers = cmd(msg["msg"], buffers)
+        response, buffers = cmd(widget, msg["msg"], buffers)
         self.send(
             {
                 "id": msg["id"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ pattern = "\"version\": \"(?P<version>.+?)\""
 
 [tool.hatch.envs.default]
 features = ["test", "dev"]
+uv = true
 
 [tool.hatch.envs.default.scripts]
 lint = [


### PR DESCRIPTION
Fixes #543

Refactor for 0.9.7 changed the API by accident.
