### PR TITLE
feat: Provide blanket _repr_mimebundle_ implementation

### DIFF
--- a/.changeset/real-jeans-fail.md
+++ b/.changeset/real-jeans-fail.md
@@ -1,0 +1,25 @@
+---
+"anywidget": patch
+---
+
+Make a blanket `_repr_mimbundle_` implementation
+
+`ipywidgets` v7 and v8 switched from using `_ipython_display_` to `_repr_mimebundle_` for rendering widgets in Jupyter. This means that depending on which version of `ipywidgets` used (v7 in Google Colab), anywidget end users need to handle the behavior of both methods. This change adds a blanket implementation of `_repr_mimebundle_` so that it is easier to wrap an `anywidget`:
+
+```python
+import anywidget
+import traitlets
+
+class Widget(anywidget.AnyWidget):
+    _esm = "index.js"
+    _css = "style.css"
+    value = traitlets.Unicode("Hello, World!").tag(sync=True)
+
+class Wrapper:
+    def __init__(self):
+        self._widget = Widget()
+
+    # Easy to forward the underlying widget's repr to the wrapper class, across all versions of ipywidgets
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        return self._widget._repr_mimebundle_(include, exclude)
+```

--- a/anywidget/_util.py
+++ b/anywidget/_util.py
@@ -11,6 +11,9 @@ from ._file_contents import FileContents
 
 _BINARY_TYPES = (memoryview, bytearray, bytes)
 _WIDGET_MIME_TYPE = "application/vnd.jupyter.widget-view+json"
+_PROTOCOL_VERSION_MAJOR = 2
+_PROTOCOL_VERSION_MINOR = 1
+_PROTOCOL_VERSION = f"{_PROTOCOL_VERSION_MAJOR}.{_PROTOCOL_VERSION_MINOR}.0"
 _ANYWIDGET_ID_KEY = "_anywidget_id"
 _ESM_KEY = "_esm"
 _CSS_KEY = "_css"
@@ -260,3 +263,19 @@ def try_file_contents(x: Any) -> FileContents | None:
         path=path,
         start_thread=_should_start_thread(path),
     )
+
+
+def repr_mimebundle(
+    model_id: str,
+    repr_text: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Create a MIME bundle for a widget representation."""
+    data = {
+        "text/plain": repr_text,
+        _WIDGET_MIME_TYPE: {
+            "version_major": _PROTOCOL_VERSION_MAJOR,
+            "version_minor": _PROTOCOL_VERSION_MINOR,
+            "model_id": model_id,
+        },
+    }
+    return data, get_repr_metadata()

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -12,8 +12,8 @@ from ._util import (
     _DEFAULT_ESM,
     _ESM_KEY,
     enable_custom_widget_manager_once,
-    get_repr_metadata,
     in_colab,
+    repr_mimebundle,
     try_file_contents,
 )
 from ._version import __version__
@@ -70,10 +70,10 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
                 setattr(cls, key, file_contents)
         _collect_anywidget_commands(cls)
 
-    if hasattr(ipywidgets.DOMWidget, "_repr_mimebundle_"):
-        # ipywidgets v8
-        def _repr_mimebundle_(self, **kwargs: dict) -> tuple[dict, dict] | None:
-            mimebundle = super()._repr_mimebundle_(**kwargs)
-            if mimebundle is None:
-                return None
-            return mimebundle, get_repr_metadata()
+    def _repr_mimebundle_(self, **kwargs: dict) -> tuple[dict, dict] | None:
+        plaintext = repr(self)
+        if len(plaintext) > 110:
+            plaintext = plaintext[:110] + "…"
+        if self._view_name is None:
+            return None
+        return repr_mimebundle(model_id=self.model_id, repr_text=plaintext)

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -10,11 +10,11 @@ import pytest
 import watchfiles
 from anywidget._descriptor import (
     _COMMS,
-    _WIDGET_MIME_TYPE,
     MimeBundleDescriptor,
     ReprMimeBundle,
 )
 from anywidget._file_contents import FileContents
+from anywidget._util import _WIDGET_MIME_TYPE
 from watchfiles import Change
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Make a blanket `_repr_mimbundle_` implementation

`ipywidgets` v7 and v8 switched from using `_ipython_display_` to `_repr_mimebundle_` for rendering widgets in Jupyter. This means that depending on which version of `ipywidgets` used (v7 in Google Colab), anywidget end users need to handle the behavior of both methods (if they want to wrap the underlying widget in another class). 

This PR adds a blanket implementation of `_repr_mimebundle_` so that it is easier to wrap an `anywidget`:

```python
import anywidget
import traitlets

class Widget(anywidget.AnyWidget):
    _esm = "index.js"
    _css = "style.css"
    value = traitlets.Unicode("Hello, World!").tag(sync=True)

class Wrapper:
    def __init__(self):
        self._widget = Widget()

    # Easy to forward the underlying widget's repr to the wrapper class, across all versions of ipywidgets
    def _repr_mimebundle_(self, include=None, exclude=None):
        return self._widget._repr_mimebundle_(include, exclude)
```
