### PR TITLE
feat: Add `%%vfile` cell magic

### DIFF
--- a/.changeset/serious-months-study.md
+++ b/.changeset/serious-months-study.md
@@ -1,0 +1,39 @@
+---
+"anywidget": patch
+---
+
+Add ipython cell magic to enable HMR within Jupyter notebooks
+
+Introduces a new experimental cell magic `%%vfile`, designed for prototyping widget ideas within Jupyter notebooks. This is not intended for production use. The goal is to enable nicer syntax highlighting of code and to allow using anywidget's Hot Module Replacement (HMR) entirely from within a notebook.
+
+Previously, anywidget ESM and CSS had to be provided as inline strings or file paths. Notebook development required editing JS/CSS as inline strings, which resulted in losing widget state to see front-end code changes. Anywidget's HMR enables live reloading of front-end code without losing state, but only by monitoring the file system (requring making separate files for the best DX). With the new `%%vfile` cell magic, you can prototype entirely from within a notebook and enjoy live reloads whenever the cell is re-executed.
+
+`In[1]`:
+
+```python
+%load_ext anywidget
+```
+
+`In[2]`:
+
+```js
+%%vfile index.js
+export default {
+  render({ model, el }) {
+    el.innerHTML = `<h1>Hello, ${model.get("name")}!</h1>`;
+  }
+}
+```
+
+`In[3]`:
+
+```py
+import anywidget
+import traitlets
+
+class Widget(anywidget.AnyWidget):
+    _esm = "vfile:index.js"
+    name = traitlets.Unicode("world")
+
+Widget()
+```

--- a/.changeset/serious-months-study.md
+++ b/.changeset/serious-months-study.md
@@ -2,11 +2,13 @@
 "anywidget": patch
 ---
 
-Add ipython cell magic to enable HMR within Jupyter notebooks
+Add IPython Cell Magic for HMR
 
-Introduces a new experimental cell magic `%%vfile`, designed for prototyping widget ideas within Jupyter notebooks. This is not intended for production use. The goal is to enable nicer syntax highlighting of code and to allow using anywidget's Hot Module Replacement (HMR) entirely from within a notebook.
+New `%%vfile` cell magic for prototyping widgets in notebooks. Enables syntax highlighting and anywidget's Hot Module Replacement (HMR) directly within the notebook.
 
-Previously, anywidget ESM and CSS had to be provided as inline strings or file paths. Notebook development required editing JS/CSS as inline strings, which resulted in losing widget state to see front-end code changes. Anywidget's HMR enables live reloading of front-end code without losing state, but only by monitoring the file system (requring making separate files for the best DX). With the new `%%vfile` cell magic, you can prototype entirely from within a notebook and enjoy live reloads whenever the cell is re-executed.
+Previously, front-end code had to be inline strings or file paths, causing loss of widget state when editing inline-strings in notebooks. The new `%%vfile` cell magic allows editing front-end code within the notebook with live reloading on cell re-execution.
+
+Use `%%vfile <filename>` to create a virtual file for either JavaScript or CSS, and use `vfile:<filename>` in `_esm` or `_css` attributes of an `AnyWidget` subclass to reference the virtual file. Anywidget applies HMR updates automatically on cell re-execution.
 
 `In[1]`:
 

--- a/anywidget/__init__.py
+++ b/anywidget/__init__.py
@@ -21,3 +21,9 @@ def _jupyter_nbextension_paths() -> list[dict]:
             "require": "anywidget/extension",
         }
     ]
+
+
+def load_ipython_extension(ipython):  # pragma: no cover
+    from ._cellmagic import load_ipython_extension
+
+    load_ipython_extension(ipython)

--- a/anywidget/__init__.py
+++ b/anywidget/__init__.py
@@ -23,7 +23,7 @@ def _jupyter_nbextension_paths() -> list[dict]:
     ]
 
 
-def load_ipython_extension(ipython):  # pragma: no cover
+def load_ipython_extension(ipython):  # type: ignore[no-untyped-def]
     from ._cellmagic import load_ipython_extension
 
     load_ipython_extension(ipython)

--- a/anywidget/_cellmagic.py
+++ b/anywidget/_cellmagic.py
@@ -5,7 +5,7 @@ import typing
 from IPython.core.magic import Magics, cell_magic, magics_class
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 
-from ._file_contents import VirtualFileContents
+from ._file_contents import _VIRTUAL_FILES, VirtualFileContents
 
 if typing.TYPE_CHECKING:
     from IPython.core.interactiveshell import InteractiveShell
@@ -14,24 +14,20 @@ if typing.TYPE_CHECKING:
 @magics_class
 class AnyWidgetMagics(Magics):
     @magic_arguments()
-    @argument(
-        "-n",
-        "--name",
-        type=str,
-    )
+    @argument("file_name", type=str, help="The name of the virtual file.")
     @cell_magic
-    def aw_file(self, line, cell):
+    def vfile(self, line, cell):
         """Create a virtual file with the contents of the cell."""
-        args = parse_argstring(AnyWidgetMagics.aw_file, line)
-        name = typing.cast(str, args.name)
+        args = parse_argstring(AnyWidgetMagics.vfile, line)
+        name = typing.cast(str, args.file_name)
         shell = typing.cast("InteractiveShell", self.shell)
         code = shell.transform_cell(cell)
-        if name in shell.user_ns:
+        if name in _VIRTUAL_FILES:
             # Update the existing VirtualFileContents object, triggering a change event
-            shell.user_ns[name].contents = code
+            _VIRTUAL_FILES[name].contents = code
         else:
             # Create a new VirtualFileContents object
-            shell.user_ns[name] = VirtualFileContents(code)
+            _VIRTUAL_FILES[name] = VirtualFileContents(code)
 
 
 def load_ipython_extension(ipython: InteractiveShell):

--- a/anywidget/_cellmagic.py
+++ b/anywidget/_cellmagic.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import typing
+
+from IPython.core.magic import Magics, cell_magic, magics_class
+from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+
+from ._file_contents import VirtualFileContents
+
+if typing.TYPE_CHECKING:
+    from IPython.core.interactiveshell import InteractiveShell
+
+
+@magics_class
+class AnyWidgetMagics(Magics):
+    @magic_arguments()
+    @argument(
+        "-n",
+        "--name",
+        type=str,
+    )
+    @cell_magic
+    def aw_file(self, line, cell):
+        """Create a virtual file with the contents of the cell."""
+        args = parse_argstring(AnyWidgetMagics.aw_file, line)
+        name = typing.cast(str, args.name)
+        shell = typing.cast("InteractiveShell", self.shell)
+        code = shell.transform_cell(cell)
+        if name in shell.user_ns:
+            # Update the existing VirtualFileContents object, triggering a change event
+            shell.user_ns[name].contents = code
+        else:
+            # Create a new VirtualFileContents object
+            shell.user_ns[name] = VirtualFileContents(code)
+
+
+def load_ipython_extension(ipython: InteractiveShell):
+    """Load the IPython extension.
+
+    Parameters
+    ----------
+    ipython : IPython.core.interactiveshell.InteractiveShell
+        The IPython shell instance.
+    """
+    ipython.register_magics(AnyWidgetMagics)

--- a/anywidget/_cellmagic.py
+++ b/anywidget/_cellmagic.py
@@ -13,10 +13,10 @@ if typing.TYPE_CHECKING:
 
 @magics_class
 class AnyWidgetMagics(Magics):
-    @magic_arguments()
-    @argument("file_name", type=str, help="The name of the virtual file.")
-    @cell_magic
-    def vfile(self, line, cell):
+    @magic_arguments()  # type: ignore[misc]
+    @argument("file_name", type=str, help="The name of the virtual file.")  # type: ignore[misc]
+    @cell_magic  # type: ignore[misc]
+    def vfile(self, line: str, cell: str) -> None:
         """Create a virtual file with the contents of the cell."""
         args = parse_argstring(AnyWidgetMagics.vfile, line)
         name = typing.cast(str, args.file_name)
@@ -30,7 +30,7 @@ class AnyWidgetMagics(Magics):
             _VIRTUAL_FILES[name] = VirtualFileContents(code)
 
 
-def load_ipython_extension(ipython: InteractiveShell):
+def load_ipython_extension(ipython: InteractiveShell) -> None:
     """Load the IPython extension.
 
     Parameters

--- a/anywidget/_cellmagic.py
+++ b/anywidget/_cellmagic.py
@@ -37,7 +37,7 @@ class AnyWidgetMagics(Magics):
             self._files[name] = vfile
             _VIRTUAL_FILES[name] = vfile
 
-    @line_magic
+    @line_magic # type: ignore[misc]
     def clear_vfiles(self, line: str) -> None:
         """Clear all virtual files."""
         self._files.clear()

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -33,7 +33,7 @@ from typing import (
     overload,
 )
 
-from ._file_contents import FileContents
+from ._file_contents import FileContents, VirtualFileContents
 from ._util import (
     _ANYWIDGET_ID_KEY,
     _DEFAULT_ESM,
@@ -324,7 +324,7 @@ class ReprMimeBundle:
         self._set_state = determine_state_setter(obj)
 
         for key, value in self._extra_state.items():
-            if isinstance(value, FileContents):
+            if isinstance(value, (VirtualFileContents, FileContents)):
                 self._extra_state[key] = str(value)
 
                 @value.changed.connect

--- a/anywidget/_descriptor.py
+++ b/anywidget/_descriptor.py
@@ -558,7 +558,7 @@ def _get_psygnal_signal_group(obj: object) -> psygnal.SignalGroup | None:
     else:
         psygnal = sys.modules.get("psygnal")
     if psygnal is None:
-        return None # type: ignore[unreachable]
+        return None  # type: ignore[unreachable]
 
     # most likely case: signal group is called "events"
     events = getattr(obj, "events", None)

--- a/anywidget/_file_contents.py
+++ b/anywidget/_file_contents.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pathlib
 import threading
+import weakref
 from collections import deque
 from typing import Iterator
 
@@ -9,7 +10,9 @@ from psygnal import Signal
 
 __all__ = ["FileContents", "VirtualFileContents", "_VIRTUAL_FILES"]
 
-_VIRTUAL_FILES: dict[str, VirtualFileContents] = {}
+_VIRTUAL_FILES: weakref.WeakValueDictionary[str, VirtualFileContents] = (
+    weakref.WeakValueDictionary()
+)
 
 
 class VirtualFileContents:

--- a/anywidget/_file_contents.py
+++ b/anywidget/_file_contents.py
@@ -7,7 +7,9 @@ from typing import Iterator
 
 from psygnal import Signal
 
-__all__ = ["FileContents", "VirtualFileContents"]
+__all__ = ["FileContents", "VirtualFileContents", "_VIRTUAL_FILES"]
+
+_VIRTUAL_FILES = {}
 
 
 class VirtualFileContents:

--- a/anywidget/_file_contents.py
+++ b/anywidget/_file_contents.py
@@ -7,6 +7,37 @@ from typing import Iterator
 
 from psygnal import Signal
 
+__all__ = ["FileContents", "VirtualFileContents"]
+
+
+class VirtualFileContents:
+    """Stores text file contents in memory and emits a signal when it changes.
+
+    Calling `str(obj)` on this object will always return the current contents.
+
+    Parameters
+    ----------
+    contents : str, optional
+        The initial contents of the file (default: "")
+    """
+
+    changed = Signal(str)
+
+    def __init__(self, contents: str = ""):
+        self._contents = contents
+
+    @property
+    def contents(self) -> str:
+        return self._contents
+
+    @contents.setter
+    def contents(self, value: str) -> None:
+        self._contents = value
+        self.changed.emit(value)
+
+    def __str__(self) -> str:
+        return self.contents
+
 
 class FileContents:
     """Object that watches for file changes and emits a signal when it changes.

--- a/anywidget/_file_contents.py
+++ b/anywidget/_file_contents.py
@@ -9,7 +9,7 @@ from psygnal import Signal
 
 __all__ = ["FileContents", "VirtualFileContents", "_VIRTUAL_FILES"]
 
-_VIRTUAL_FILES = {}
+_VIRTUAL_FILES: dict[str, VirtualFileContents] = {}
 
 
 class VirtualFileContents:

--- a/anywidget/_util.py
+++ b/anywidget/_util.py
@@ -7,7 +7,7 @@ import sys
 from functools import lru_cache
 from typing import Any
 
-from ._file_contents import FileContents
+from ._file_contents import _VIRTUAL_FILES, FileContents, VirtualFileContents
 
 _BINARY_TYPES = (memoryview, bytearray, bytes)
 _WIDGET_MIME_TYPE = "application/vnd.jupyter.widget-view+json"
@@ -250,8 +250,11 @@ def try_file_path(x: Any) -> pathlib.Path | None:
     return None
 
 
-def try_file_contents(x: Any) -> FileContents | None:
+def try_file_contents(x: Any) -> FileContents | VirtualFileContents | None:
     """Try to coerce x into a FileContents object."""
+    if x in _VIRTUAL_FILES:
+        return _VIRTUAL_FILES[x]
+
     maybe_path = try_file_path(x)
     if maybe_path is None:
         return None

--- a/anywidget/experimental.py
+++ b/anywidget/experimental.py
@@ -47,7 +47,7 @@ def widget(
         kwargs["_css"] = css
 
     def _decorator(cls: _T) -> _T:
-        setattr(cls, "_repr_mimebundle_", MimeBundleDescriptor(**kwargs)) # noqa: B010
+        setattr(cls, "_repr_mimebundle_", MimeBundleDescriptor(**kwargs))  # noqa: B010
         return cls
 
     return _decorator

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -6,7 +6,7 @@ from typing import Any
 import ipywidgets
 import traitlets.traitlets as t
 
-from ._file_contents import FileContents
+from ._file_contents import FileContents, VirtualFileContents
 from ._util import (
     _ANYWIDGET_ID_KEY,
     _CSS_KEY,
@@ -41,7 +41,7 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
             if hasattr(self, key) and not self.has_trait(key):
                 value = getattr(self, key)
                 anywidget_traits[key] = t.Unicode(str(value)).tag(sync=True)
-                if isinstance(value, FileContents):
+                if isinstance(value, (VirtualFileContents, FileContents)):
                     value.changed.connect(
                         lambda new_contents, key=key: setattr(self, key, new_contents)
                     )

--- a/anywidget/widget.py
+++ b/anywidget/widget.py
@@ -1,4 +1,5 @@
 """AnyWidget base class for custom Jupyter widgets."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -76,5 +77,5 @@ class AnyWidget(ipywidgets.DOMWidget):  # type: ignore [misc]
         if len(plaintext) > 110:
             plaintext = plaintext[:110] + "…"
         if self._view_name is None:
-            return None # type: ignore[unreachable]
+            return None  # type: ignore[unreachable]
         return repr_mimebundle(model_id=self.model_id, repr_text=plaintext)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,10 @@ module = "anywidget.widget"  # makes heavy use of traitlets, which is not typed
 disallow_untyped_calls = false
 
 [[tool.mypy.overrides]]
+module = "anywidget._cellmagic"  # makes heavy use of IPython, which is not typed
+disallow_untyped_calls = false
+
+[[tool.mypy.overrides]]
 # this might be missing in pre-commit, but they aren't typed anyway
 module = ["ipywidgets", "traitlets.*", "comm", "IPython.*"]
 ignore_missing_imports = true

--- a/tests/test_cellmagic.py
+++ b/tests/test_cellmagic.py
@@ -1,0 +1,13 @@
+from anywidget._file_contents import VirtualFileContents
+from IPython.testing.globalipapp import get_ipython
+
+maybe_ipython = get_ipython()
+assert maybe_ipython is not None  # to make mypy happy
+ip = maybe_ipython
+ip.run_line_magic("load_ext", "anywidget")
+
+
+def test_creates_virtual_file_contents():
+    ip.run_cell_magic("aw_file", "-n testing_123", "Hello, world!")
+    assert isinstance(ip.user_ns["testing_123"], VirtualFileContents)
+    assert str(ip.user_ns["testing_123"]) == "Hello, world!\n"

--- a/tests/test_cellmagic.py
+++ b/tests/test_cellmagic.py
@@ -1,4 +1,4 @@
-from anywidget._file_contents import VirtualFileContents
+from anywidget._file_contents import _VIRTUAL_FILES, VirtualFileContents
 from IPython.testing.globalipapp import get_ipython
 
 maybe_ipython = get_ipython()
@@ -8,6 +8,7 @@ ip.run_line_magic("load_ext", "anywidget")
 
 
 def test_creates_virtual_file_contents():
-    ip.run_cell_magic("aw_file", "-n testing_123", "Hello, world!")
-    assert isinstance(ip.user_ns["testing_123"], VirtualFileContents)
-    assert str(ip.user_ns["testing_123"]) == "Hello, world!\n"
+    ip.run_cell_magic("vfile", "data.txt", "Hello, world!")
+    assert "data.txt" in _VIRTUAL_FILES
+    assert isinstance(_VIRTUAL_FILES["data.txt"], VirtualFileContents)
+    assert str(_VIRTUAL_FILES["data.txt"]) == "Hello, world!\n"

--- a/tests/test_cellmagic.py
+++ b/tests/test_cellmagic.py
@@ -9,6 +9,13 @@ ip.run_line_magic("load_ext", "anywidget")
 
 def test_creates_virtual_file_contents():
     ip.run_cell_magic("vfile", "data.txt", "Hello, world!")
-    assert "data.txt" in _VIRTUAL_FILES
-    assert isinstance(_VIRTUAL_FILES["data.txt"], VirtualFileContents)
-    assert str(_VIRTUAL_FILES["data.txt"]) == "Hello, world!\n"
+    assert "vfile:data.txt" in _VIRTUAL_FILES
+    assert isinstance(_VIRTUAL_FILES["vfile:data.txt"], VirtualFileContents)
+    assert str(_VIRTUAL_FILES["vfile:data.txt"]) == "Hello, world!\n"
+
+
+def test_clears_vfiles():
+    ip.run_cell_magic("vfile", "data.txt", "Hello,\nworld!")
+    assert "vfile:data.txt" in _VIRTUAL_FILES
+    ip.run_line_magic("clear_vfiles", "")
+    assert "vfile:data.txt" not in _VIRTUAL_FILES

--- a/tests/test_file_contents.py
+++ b/tests/test_file_contents.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import watchfiles
-from anywidget._file_contents import FileContents
+from anywidget._file_contents import FileContents, VirtualFileContents
 from watchfiles import Change
 
 
@@ -149,3 +149,14 @@ def test_missing_file_fails():
 
     with pytest.raises(ValueError):
         FileContents(pathlib.Path("not_a_file.txt"))
+
+
+def test_virtual_file_contents():
+    CONTENTS = "hello, world"
+    contents = VirtualFileContents(CONTENTS)
+    assert str(contents) == CONTENTS
+    mock_changed = MagicMock()
+    contents.changed.connect(mock_changed)
+    contents.contents = "blah"
+    mock_changed.assert_called_once_with("blah")
+    assert str(contents) == "blah"


### PR DESCRIPTION
This PR a new experimental cell magic `%%vfile`, designed for prototyping widget ideas within Jupyter notebooks. This is not intended for production use. The goal is to enable nicer syntax highlighting of code and to allow using anywidget's Hot Module Replacement (HMR) entirely from within a notebook.

Previously, anywidget ESM and CSS had to be provided as inline strings or file paths. Notebook development required editing JS/CSS as inline strings, which resulted in losing widget state to see front-end code changes. Anywidget's HMR enables live reloading of front-end code without losing state, but only by monitoring the file system (requring making separate files for the best DX). 

With the new `%%vfile` cell magic, you can prototype entirely from within a a single notebook and enjoy "live" reloads whenever the vfile cell is re-executed.

`In[1]`:

```python
%load_ext anywidget
```

`In[2]`:

```js
%%vfile index.js
export default {
  render({ model, el }) {
    el.innerHTML = `<h1>Hello, ${model.get("name")}!</h1>`;
  }
}
```

`In[3]`:

```py
import anywidget
import traitlets

class Widget(anywidget.AnyWidget):
    _esm = "vfile:index.js"
    name = traitlets.Unicode("world")

Widget()
```

Example:

https://github.com/manzt/anywidget/assets/24403730/a6bd172d-6fac-4bf5-bd93-c9a07c328ba7

Open questions:

I'm not entirely sure what the magic API should look like. We could have `%%esm` and `%%css`, but under the hood they do the same thing. I'd also like to avoid populating variables in the notebook namespace with objects like `FileContents` which aren't meant for end users.

Right now, the `%%vfile` requires a virtual file name, that we can then match to whatever is passed to `_esm`. I guess would could be more pedantic about his with something like requiring a prefix in `_esm = "vfile:index.js"`.

EDIT: Ok I've decided to be pedantic and require `vfile:` prefix.