### PR TITLE
Add trove classifiers to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,16 @@ dependencies =  [
     "typing-extensions>=4.2.0",
     "psygnal>=0.8.1",
 ]
+classifiers = [
+    "Framework :: Jupyter",
+    "Framework :: Jupyter :: JupyterLab",
+    "Framework :: Jupyter :: JupyterLab :: 4",
+    "Framework :: Jupyter :: JupyterLab :: Extensions",
+    "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
The framework classifiers should make anywidget discoverable within the JLab extension manager.

See [classifiers](https://pypi.org/classifiers/).