### PR TITLE
Change the property name from count to value

### DIFF
--- a/docs/src/pages/en/getting-started.mdx
+++ b/docs/src/pages/en/getting-started.mdx
@@ -65,7 +65,7 @@ CounterWidget(value=42)
 
 What's going on here:
 
-- `count` is a stateful property that both the client JavaScript and Python have access to.
+- `value` is a stateful property that both the client JavaScript and Python have access to.
   Shared state is defined via [traitlets](https://traitlets.readthedocs.io/en/stable/) with the `sync=True`
   keyword argument.
 


### PR DESCRIPTION
The property name in the example is `value` instead of `count`. 

