### PR TITLE
feat: Patch ipywidgets to be more flexible with child widgets

### DIFF
--- a/anywidget/__init__.py
+++ b/anywidget/__init__.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from ._patch_ipywidgets import _patch_ipywidgets
 from ._version import __version__
 from .widget import AnyWidget
 
 __all__ = ["AnyWidget", "__version__"]
+
+_patch_ipywidgets()
 
 
 def _jupyter_labextension_paths() -> list[dict]:

--- a/anywidget/_patch_ipywidgets.py
+++ b/anywidget/_patch_ipywidgets.py
@@ -1,0 +1,104 @@
+"""ipywidgets patch module.
+
+Patches ipywidgets to allow for more flexible serialization and
+deserialization of (any)widgets by allowing objects that are not
+strict instances of `ipywidgets.Widget`.
+
+Only `ipywidgets.Box` and `ipywidgets.widgets.widget_link.Link`
+give problems. This code is mostly vendored from ipywidgets and
+modified to allow for more flexibility.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import ipywidgets
+import traitlets
+from ipywidgets.widgets.trait_types import TypedTuple
+from ipywidgets.widgets.widget import Widget, _instances
+
+from ._descriptor import _COMMS
+
+
+def _get_model_id(x: t.Any) -> str | None:
+    """Get the model id of a widget or comm."""
+    if isinstance(x, Widget):
+        return x.model_id
+    maybe_comm = _COMMS.get(id(x), None)
+    return getattr(maybe_comm, "comm_id", None)
+
+
+def _widget_to_json(x: t.Any, obj: t.Any) -> t.Any:
+    """Recursively convert a widget to json."""
+    if isinstance(x, dict):
+        return {k: _widget_to_json(v, obj) for k, v in x.items()}
+    elif isinstance(x, (list, tuple)):
+        return [_widget_to_json(v, obj) for v in x]
+    model_id = _get_model_id(x)
+    return f"IPY_MODEL_{model_id}" if model_id else x
+
+
+def _json_to_widget(x: t.Any, obj: t.Any) -> t.Any:
+    """Recursively convert json to a widget."""
+    if isinstance(x, dict):
+        return {k: _json_to_widget(v, obj) for k, v in x.items()}
+    elif isinstance(x, (list, tuple)):
+        return [_json_to_widget(v, obj) for v in x]
+    elif isinstance(x, str) and x.startswith("IPY_MODEL_") and x[10:] in _instances:
+        return _instances[x[10:]]
+    else:
+        return x
+
+
+class WidgetTrait(traitlets.TraitType):
+    """Traitlet for validating things that can be (de)serialized into widgets."""
+
+    # anything that can get a model id is ok as a widget
+    def validate(self, obj: t.Any, value: t.Any):
+        if _get_model_id(value) is not None:
+            return value
+        else:
+            self.error(obj, value)
+
+
+# Adapted from https://github.com/jupyter-widgets/ipywidgets/blob/bb2edf78e7dac26e4b15522a267d7b477026a840/python/ipywidgets/ipywidgets/widgets/widget_link.py#L15
+class WidgetTraitTuple(traitlets.Tuple):
+    """Traitlet for validating a single (Widget, 'trait_name') pair."""
+
+    info_text = "A (Widget, 'trait_name') pair"
+
+    def __init__(self):
+        super().__init__(WidgetTrait(), traitlets.Unicode())
+
+    def validate_elements(self, obj: t.Any, value: t.Any) -> t.Any:
+        value = super().validate_elements(obj, value)
+        widget, trait_name = value
+        trait = widget.traits().get(trait_name)
+        trait_repr = f"{widget.__class__.__name__}.{trait_name}"
+        # Can't raise TraitError because the parent will swallow the message
+        # and throw it away in a new, less informative TraitError
+        if trait is None:
+            raise TypeError(f"No such trait: {trait_repr}")
+        elif not trait.metadata.get("sync"):
+            raise TypeError(f"{trait_repr} cannot be synced")
+        return value
+
+
+def patch_ipywidgets() -> None:
+    """Patch ipywidgets to allow for more flexible serialization and deserialization."""
+    ipywidgets.Box.children.metadata["to_json"] = _widget_to_json
+    ipywidgets.Box.children.metadata["from_json"] = _json_to_widget
+    ipywidgets.Box.children.validate = TypedTuple(WidgetTrait()).validate
+
+    ipywidgets.widgets.widget_link.Link.source.metadata["to_json"] = _widget_to_json
+    ipywidgets.widgets.widget_link.Link.source.metadata["from_json"] = _json_to_widget
+    ipywidgets.widgets.widget_link.Link.source.validate_elements = (
+        WidgetTraitTuple().validate_elements
+    )
+
+    ipywidgets.widgets.widget_link.Link.target.metadata["to_json"] = _widget_to_json
+    ipywidgets.widgets.widget_link.Link.target.metadata["from_json"] = _json_to_widget
+    ipywidgets.widgets.widget_link.Link.target.validate_elements = (
+        WidgetTraitTuple().validate_elements
+    )


### PR DESCRIPTION
## Summary

ipywidgets performs an `isinstance(x, Widget)` check with their container classes (i.e., `Box`, `Link`). This restricts the use of only classes that derive from `ipywidgets.Widget`, which is a very large class with many methods.

This is problematic because it ties the entire widgets ecosystem (and anywidget) to a large, monolithic class. Widget authors inherit from this class, and now their top-level APIs for end users have a set of methods that should be considered private to end users but are useful for widget developers.

This makes it difficult to innovate on Python-side APIs, as developers are forced to inherit from this large class even if they only need basic widget functionality.

In anywidget, it _really_ holds us back from iterating on the Python side of thing because we don't want to break compatability with ipywidgets but we _need_ other APIs (#579, #628).

## Solution

This PR patches ipywidgets to allow widgets composed from non-`Widget` base classes. The patch performs flexible serialization and deserialization by checking for the model_id attribute instead of strict instance checks.

We should probably come up with a _protocol_ for getting the `model_id` attribute, making this even less tied to anywidget/ipywidgets, but for now, this is a good start.
