### PR TITLE
docs:  fixing not working link to community examples on jupyter-widgets-the-good-parts page

### DIFF
--- a/docs/src/pages/en/jupyter-widgets-the-good-parts.mdx
+++ b/docs/src/pages/en/jupyter-widgets-the-good-parts.mdx
@@ -415,7 +415,7 @@ return value is sent to the front end.
 
 A more complex serialization example might be to serialize a `pandas.DataFrame`
 to the [Apache Arrow](https://arrow.apache.org/#) format or a `numpy` array to
-its underlying bytes. Several [community examples](./community) should serve as
+its underlying bytes. Several [community examples](/en/community) should serve as
 good starting points to learn about more advanced use cases.
 
 ## Tips for beginners


### PR DESCRIPTION
Problem: 
When clicking `community examples` link on `Jupyter Widgets the Good Parts` docs page, navigation is made to non existing page resulting in 404 page.

Diagnosis:
relative link `./community` is used. It does work when current page is `en/jupyter-widgets-the-good-parts` as it happens on astro dev. But (probably) hosting service makes 301 redirection to `en/jupyter-widgets-the-good-parts/` (mark added end slash). This makes link `./community` to navigate to `/en/jupyter-widgets-the-good-parts/community` instead `/en/community` which result in 404

Solution:
change link href to absolute path making it resilient to addition of "closing" url slash