### PR TITLE
Fix link in jupyter-widgets-the-good-parts.mdx

### DIFF
--- a/docs/src/pages/en/jupyter-widgets-the-good-parts.mdx
+++ b/docs/src/pages/en/jupyter-widgets-the-good-parts.mdx
@@ -415,7 +415,7 @@ return value is sent to the front end.
 
 A more complex serialization example might be to serialize a `pandas.DataFrame`
 to the [Apache Arrow](https://arrow.apache.org/#) format or a `numpy` array to
-its underlying bytes. Several [community examples](./community) should serve as
+its underlying bytes. Several [community examples](/community) should serve as
 good starting points to learn about more advanced use cases.
 
 ## Tips for beginners

--- a/docs/src/pages/en/jupyter-widgets-the-good-parts.mdx
+++ b/docs/src/pages/en/jupyter-widgets-the-good-parts.mdx
@@ -415,7 +415,7 @@ return value is sent to the front end.
 
 A more complex serialization example might be to serialize a `pandas.DataFrame`
 to the [Apache Arrow](https://arrow.apache.org/#) format or a `numpy` array to
-its underlying bytes. Several [community examples](/community) should serve as
+its underlying bytes. Several [community examples](/en/community) should serve as
 good starting points to learn about more advanced use cases.
 
 ## Tips for beginners


### PR DESCRIPTION
Randomly found this `./` link in docs. On localhost that redirects correctly, but when deployed, the resulting link url is [https://anywidget.dev/en/jupyter-widgets-the-good-parts/community](https://anywidget.dev/en/jupyter-widgets-the-good-parts/community) which 404s.

Seems to be the only occurence.