### PR TITLE
feat(react): Add support for React 19

### DIFF
--- a/.changeset/wise-poets-look.md
+++ b/.changeset/wise-poets-look.md
@@ -1,0 +1,5 @@
+---
+"@anywidget/react": minor
+---
+
+Support React 19

--- a/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
@@ -112,8 +112,8 @@ src/ipyfoo/static
 	},
 	"dependencies": {
 		"@anywidget/react": "0.0.8",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {}
 }",
@@ -341,12 +341,12 @@ src/ipyfoo/static
 	},
 	"dependencies": {
 		"@anywidget/react": "0.0.8",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
-		"@types/react": "^18.3.12",
-		"@types/react-dom": "^18.3.1",
+		"@types/react": "^19.0.1",
+		"@types/react-dom": "^19.0.2",
 		"typescript": "^5.7.2"
 	}
 }",
@@ -1304,8 +1304,8 @@ src/ipyfoo/static
 	},
 	"dependencies": {
 		"@anywidget/react": "0.0.8",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
 		"esbuild": "^0.24.0"
@@ -1535,12 +1535,12 @@ src/ipyfoo/static
 	},
 	"dependencies": {
 		"@anywidget/react": "0.0.8",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
-		"@types/react": "^18.3.12",
-		"@types/react-dom": "^18.3.1",
+		"@types/react": "^19.0.1",
+		"@types/react-dom": "^19.0.2",
 		"typescript": "^5.7.2",
 		"esbuild": "^0.24.0"
 	}

--- a/packages/create-anywidget/package.json
+++ b/packages/create-anywidget/package.json
@@ -28,11 +28,11 @@
 		"@anywidget/react": "workspace:^",
 		"@anywidget/types": "workspace:^",
 		"@types/node": "^22.10.1",
-		"@types/react": "^18.3.12",
-		"@types/react-dom": "^18.3.1",
+		"@types/react": "^19.0.1",
+		"@types/react-dom": "^19.0.2",
 		"esbuild": "^0.24.0",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
 		"typescript": "^5.7.2"
 	}
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,16 +15,16 @@
 		}
 	},
 	"peerDependencies": {
-		"@types/react": "^18.0.0",
-		"@types/react-dom": "^18.0.0",
-		"react": "^18.0.0",
-		"react-dom": "^18.0.0"
+		"@types/react": "^18.0.0 || ^19.0.0",
+		"@types/react-dom": "^18.0.0 || ^19.0.0",
+		"react": "^18.0.0 || ^19.0.0",
+		"react-dom": "^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {
-		"@types/react": "^18.3.12",
-		"@types/react-dom": "^18.3.1",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"@types/react": "^19.0.1",
+		"@types/react-dom": "^19.0.2",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"dependencies": {
 		"@anywidget/types": "workspace:^"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,7 +122,7 @@ importers:
     dependencies:
       '@jupyter-widgets/base':
         specifier: ^6
-        version: 6.0.10(react@18.3.1)
+        version: 6.0.10(react@19.0.0)
       '@lukeed/uuid':
         specifier: ^2.0.1
         version: 2.0.1
@@ -135,7 +135,7 @@ importers:
         version: link:../types
       '@jupyter-widgets/base-manager':
         specifier: ^1.0.11
-        version: 1.0.11(react@18.3.1)
+        version: 1.0.11(react@19.0.0)
 
   packages/create-anywidget:
     dependencies:
@@ -159,20 +159,20 @@ importers:
         specifier: ^22.10.1
         version: 22.10.1
       '@types/react':
-        specifier: ^18.3.12
-        version: 18.3.12
+        specifier: ^19.0.1
+        version: 19.0.1
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.0.2
+        version: 19.0.2(@types/react@19.0.1)
       esbuild:
         specifier: ^0.24.0
         version: 0.24.0
       react:
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.0.0
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -186,17 +186,17 @@ importers:
         version: link:../types
     devDependencies:
       '@types/react':
-        specifier: ^18.3.12
-        version: 18.3.12
+        specifier: ^19.0.1
+        version: 19.0.1
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.0.2
+        version: 19.0.2(@types/react@19.0.1)
       react:
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.0.0
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
 
   packages/signals: {}
 
@@ -1796,17 +1796,19 @@ packages:
   '@types/react-dom@18.3.0':
     resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
 
-  '@types/react-dom@18.3.1':
-    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
-
-  '@types/react@18.3.11':
-    resolution: {integrity: sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==}
+  '@types/react-dom@19.0.2':
+    resolution: {integrity: sha512-c1s+7TKFaDRRxr1TxccIX2u7sfCnc3RxkVyBIUA2lCpyqCF+QoAwQ/CBg7bsMdVwP120HEH143VQezKtef5nCg==}
+    peerDependencies:
+      '@types/react': ^19.0.0
 
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
 
   '@types/react@18.3.4':
     resolution: {integrity: sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==}
+
+  '@types/react@19.0.1':
+    resolution: {integrity: sha512-YW6614BDhqbpR5KtUYzTA+zlA7nayzJRA9ljz9CQoxthR0sDisYZLuvSMsil36t4EH/uAt8T52Xb4sVw17G+SQ==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -3805,6 +3807,11 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-dom@19.0.0:
+    resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
+    peerDependencies:
+      react: ^19.0.0
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -3814,6 +3821,10 @@ packages:
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.0.0:
+    resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -3978,6 +3989,9 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scheduler@0.25.0:
+    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
   schema-utils@4.2.0:
     resolution: {integrity: sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==}
@@ -5920,10 +5934,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@jupyter-widgets/base-manager@1.0.11(react@18.3.1)':
+  '@jupyter-widgets/base-manager@1.0.11(react@19.0.0)':
     dependencies:
-      '@jupyter-widgets/base': 6.0.10(react@18.3.1)
-      '@jupyterlab/services': 7.2.5(react@18.3.1)
+      '@jupyter-widgets/base': 6.0.10(react@19.0.0)
+      '@jupyterlab/services': 7.2.5(react@19.0.0)
       '@lumino/coreutils': 2.2.0
       base64-js: 1.5.1
       sanitize-html: 2.13.0
@@ -5932,9 +5946,9 @@ snapshots:
       - react
       - utf-8-validate
 
-  '@jupyter-widgets/base@6.0.10(react@18.3.1)':
+  '@jupyter-widgets/base@6.0.10(react@19.0.0)':
     dependencies:
-      '@jupyterlab/services': 7.2.5(react@18.3.1)
+      '@jupyterlab/services': 7.2.5(react@19.0.0)
       '@lumino/coreutils': 2.2.0
       '@lumino/messaging': 1.10.3
       '@lumino/widgets': 2.5.0
@@ -5970,12 +5984,12 @@ snapshots:
     dependencies:
       '@lumino/coreutils': 2.2.0
 
-  '@jupyterlab/services@7.2.5(react@18.3.1)':
+  '@jupyterlab/services@7.2.5(react@19.0.0)':
     dependencies:
       '@jupyter/ydoc': 2.1.1
       '@jupyterlab/coreutils': 6.2.5
       '@jupyterlab/nbformat': 4.2.5
-      '@jupyterlab/settingregistry': 4.2.5(react@18.3.1)
+      '@jupyterlab/settingregistry': 4.2.5(react@19.0.0)
       '@jupyterlab/statedb': 4.2.5
       '@lumino/coreutils': 2.2.0
       '@lumino/disposable': 2.1.3
@@ -5988,7 +6002,7 @@ snapshots:
       - react
       - utf-8-validate
 
-  '@jupyterlab/settingregistry@4.2.5(react@18.3.1)':
+  '@jupyterlab/settingregistry@4.2.5(react@19.0.0)':
     dependencies:
       '@jupyterlab/nbformat': 4.2.5
       '@jupyterlab/statedb': 4.2.5
@@ -5996,10 +6010,10 @@ snapshots:
       '@lumino/coreutils': 2.2.0
       '@lumino/disposable': 2.1.3
       '@lumino/signaling': 2.1.3
-      '@rjsf/utils': 5.20.1(react@18.3.1)
+      '@rjsf/utils': 5.20.1(react@19.0.0)
       ajv: 8.17.1
       json5: 2.2.3
-      react: 18.3.1
+      react: 19.0.0
 
   '@jupyterlab/statedb@4.2.5':
     dependencies:
@@ -6223,13 +6237,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rjsf/utils@5.20.1(react@18.3.1)':
+  '@rjsf/utils@5.20.1(react@19.0.0)':
     dependencies:
       json-schema-merge-allof: 0.8.1
       jsonpointer: 5.0.1
       lodash: 4.17.21
       lodash-es: 4.17.21
-      react: 18.3.1
+      react: 19.0.0
       react-is: 18.3.1
 
   '@rollup/pluginutils@4.2.1':
@@ -6660,16 +6674,11 @@ snapshots:
 
   '@types/react-dom@18.3.0':
     dependencies:
-      '@types/react': 18.3.11
-
-  '@types/react-dom@18.3.1':
-    dependencies:
       '@types/react': 18.3.12
 
-  '@types/react@18.3.11':
+  '@types/react-dom@19.0.2(@types/react@19.0.1)':
     dependencies:
-      '@types/prop-types': 15.7.12
-      csstype: 3.1.3
+      '@types/react': 19.0.1
 
   '@types/react@18.3.12':
     dependencies:
@@ -6679,6 +6688,10 @@ snapshots:
   '@types/react@18.3.4':
     dependencies:
       '@types/prop-types': 15.7.12
+      csstype: 3.1.3
+
+  '@types/react@19.0.1':
+    dependencies:
       csstype: 3.1.3
 
   '@types/retry@0.12.0': {}
@@ -9074,6 +9087,11 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-dom@19.0.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      scheduler: 0.25.0
+
   react-is@18.3.1: {}
 
   react-refresh@0.14.2: {}
@@ -9081,6 +9099,8 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.0.0: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -9358,6 +9378,8 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  scheduler@0.25.0: {}
 
   schema-utils@4.2.0:
     dependencies:


### PR DESCRIPTION
Supports both React 18 & 19 as possible peer dependencies in the
`@anywidget/react` module.
