### PR TITLE
fix(deno): Change `buffer_paths` from `Array<string>` to `Array<Array<string>>`

### DIFF
--- a/.changeset/cuddly-glasses-sell.md
+++ b/.changeset/cuddly-glasses-sell.md
@@ -1,0 +1,5 @@
+---
+"@anywidget/deno": patch
+---
+
+Change `buffer_paths` from `Array<string>` to `Array<Array<string>>`

--- a/packages/deno/src/utilities.ts
+++ b/packages/deno/src/utilities.ts
@@ -9,16 +9,16 @@ export function remove_buffers<T extends Record<string, unknown>>(
 ): {
 	state: { [K in keyof T]: T[K] extends Uint8Array ? null : T[K] };
 	buffers: Array<Uint8Array>;
-	buffer_paths: Array<string>;
+	buffer_paths: Array<[string]>;
 } {
 	let buffers: Array<Uint8Array> = [];
-	let buffer_paths: Array<string> = [];
+	let buffer_paths: Array<[string]> = [];
 	let out: Record<string, unknown> = {};
 	for (let key in state) {
 		if (state[key] instanceof Uint8Array) {
 			out[key] = null;
 			buffers.push(state[key]);
-			buffer_paths.push(key);
+			buffer_paths.push([key]);
 		} else {
 			out[key] = state[key];
 		}

--- a/packages/deno/test.ts
+++ b/packages/deno/test.ts
@@ -143,6 +143,6 @@ Deno.test("remove_buffers extracts buffers from message", () => {
 			},
 		},
 		buffers: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])],
-		buffer_paths: ["a", "c"],
+		buffer_paths: [["a"], ["c"]],
 	});
 });


### PR DESCRIPTION
The previous implemention incorrectly serialized buffers:

https://github.com/jupyter-widgets/ipywidgets/blob/main/packages/schema/messages.md#implementing-the-jupyter-widgets-protocol-in-the-kernel-1