### PR TITLE
fix: comm messages were lost before model was loaded

### DIFF
--- a/.changeset/happy-windows-refuse.md
+++ b/.changeset/happy-windows-refuse.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+Comm messages sent quickly after the creation of a widget could be lost because custom widgets' models were loaded asynchronously

--- a/packages/anywidget/src/widget.js
+++ b/packages/anywidget/src/widget.js
@@ -309,53 +309,58 @@ class Runtime {
 	/** @type {import('solid-js').Resource<Result<AnyWidget & { url: string }>>} */
 	// @ts-expect-error - Set synchronously in constructor.
 	#widget_result;
+	/** @type {Promise<void>} */
+	model_created;
 
 	/** @param {base.DOMWidgetModel} model */
 	constructor(model) {
-		this.#disposer = solid.createRoot((dispose) => {
-			let [css, set_css] = solid.createSignal(model.get("_css"));
-			model.on("change:_css", () => {
-				let id = model.get("_anywidget_id");
-				console.debug(`[anywidget] css hot updated: ${id}`);
-				set_css(model.get("_css"));
-			});
-			solid.createEffect(() => {
-				let id = model.get("_anywidget_id");
-				load_css(css(), id);
-			});
+		this.model_created = new Promise((resolve) => {
+			this.#disposer = solid.createRoot((dispose) => {
+				let [css, set_css] = solid.createSignal(model.get("_css"));
+				model.on("change:_css", () => {
+					let id = model.get("_anywidget_id");
+					console.debug(`[anywidget] css hot updated: ${id}`);
+					set_css(model.get("_css"));
+				});
+				solid.createEffect(() => {
+					let id = model.get("_anywidget_id");
+					load_css(css(), id);
+				});
 
-			/** @type {import("solid-js").Signal<string>} */
-			let [esm, setEsm] = solid.createSignal(model.get("_esm"));
-			model.on("change:_esm", async () => {
-				let id = model.get("_anywidget_id");
-				console.debug(`[anywidget] esm hot updated: ${id}`);
-				setEsm(model.get("_esm"));
+				/** @type {import("solid-js").Signal<string>} */
+				let [esm, setEsm] = solid.createSignal(model.get("_esm"));
+				model.on("change:_esm", async () => {
+					let id = model.get("_anywidget_id");
+					console.debug(`[anywidget] esm hot updated: ${id}`);
+					setEsm(model.get("_esm"));
+				});
+				/** @type {void | (() => Awaitable<void>)} */
+				let cleanup;
+				this.#widget_result = solid.createResource(esm, async (update) => {
+					await safe_cleanup(cleanup, "initialize");
+					try {
+						model.off(null, null, INITIALIZE_MARKER);
+						let widget = await load_widget(update, model.get("_anywidget_id"));
+						resolve();
+						cleanup = await widget.initialize?.({
+							model: model_proxy(model, INITIALIZE_MARKER),
+							experimental: {
+								// @ts-expect-error - bind isn't working
+								invoke: invoke.bind(null, model),
+							},
+						});
+						return ok(widget);
+					} catch (e) {
+						return error(e);
+					}
+				})[0];
+				return () => {
+					cleanup?.();
+					model.off("change:_css");
+					model.off("change:_esm");
+					dispose();
+				};
 			});
-			/** @type {void | (() => Awaitable<void>)} */
-			let cleanup;
-			this.#widget_result = solid.createResource(esm, async (update) => {
-				await safe_cleanup(cleanup, "initialize");
-				try {
-					model.off(null, null, INITIALIZE_MARKER);
-					let widget = await load_widget(update, model.get("_anywidget_id"));
-					cleanup = await widget.initialize?.({
-						model: model_proxy(model, INITIALIZE_MARKER),
-						experimental: {
-							// @ts-expect-error - bind isn't working
-							invoke: invoke.bind(null, model),
-						},
-					});
-					return ok(widget);
-				} catch (e) {
-					return error(e);
-				}
-			})[0];
-			return () => {
-				cleanup?.();
-				model.off("change:_css");
-				model.off("change:_esm");
-				dispose();
-			};
 		});
 	}
 
@@ -451,6 +456,15 @@ export default function ({ DOMWidgetModel, DOMWidgetView }) {
 				}
 			});
 			RUNTIMES.set(this, runtime);
+		}
+
+		/** @param {Parameters<InstanceType<DOMWidgetModel>["_handle_comm_msg"]>} msg */
+		async _handle_comm_msg(...msg) {
+			const runtime = RUNTIMES.get(this);
+			if (runtime !== undefined) {
+				await runtime.model_created;
+				return super._handle_comm_msg(...msg);
+			}
 		}
 
 		/**

--- a/packages/anywidget/src/widget.js
+++ b/packages/anywidget/src/widget.js
@@ -315,7 +315,7 @@ class Runtime {
 	/** @param {base.DOMWidgetModel} model */
 	constructor(model) {
 		/** @type {PromiseWithResolvers<void>} */
-		const {promise, resolve} = Promise.withResolvers();
+		const { promise, resolve } = Promise.withResolvers();
 		this.ready = promise;
 		this.#disposer = solid.createRoot((dispose) => {
 			let [css, set_css] = solid.createSignal(model.get("_css"));


### PR DESCRIPTION
As I explained in the related issue https://github.com/manzt/anywidget/issues/803, any comm messages sent to the widget before it's model was loaded were lost. This should ensure that those messages are also processed.

Fixes: https://github.com/manzt/anywidget/issues/803.