### PR TITLE
fix(anywidget): Move `@anywidget/types` from `devDependencies` to `dependencies`

### DIFF
--- a/.changeset/metal-jokes-shine.md
+++ b/.changeset/metal-jokes-shine.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+Move `@anywidget/types` from devDependencies to dependencies

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"scripts": {
 		"build": "rspack build -c ./packages/anywidget/scripts/jlab.config.cjs",
 		"build:packages": "tsc --build && pnpm --filter=\"./packages/**\" -r build && pnpm publint",
-		"clean": "rm -rf anywidget/nbextension/index.js anywidget/labextension && pnpm -r exec rm -rf dist",
+		"clean": "rm -rf dist anywidget/nbextension/index.js anywidget/labextension && pnpm -r exec rm -rf dist",
 		"version": "changeset version",
 		"release": "pnpm build:packages && uv build && changeset publish && uvx twine upload --skip-existing dist/*",
 		"test": "vitest --environment=happy-dom --run",

--- a/packages/anywidget/package.json
+++ b/packages/anywidget/package.json
@@ -20,12 +20,12 @@
 		"build": "node scripts/build.cjs"
 	},
 	"dependencies": {
-		"@jupyter-widgets/base": "^6",
+		"@anywidget/types": "workspace:^",
 		"@lukeed/uuid": "^2.0.1",
 		"solid-js": "^1.9.4"
 	},
 	"devDependencies": {
-		"@anywidget/types": "workspace:^",
+		"@jupyter-widgets/base": "^6",
 		"@jupyter-widgets/base-manager": "^1.0.11"
 	},
 	"jupyterlab": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,9 +120,9 @@ importers:
 
   packages/anywidget:
     dependencies:
-      '@jupyter-widgets/base':
-        specifier: ^6
-        version: 6.0.10(react@19.0.0)
+      '@anywidget/types':
+        specifier: workspace:^
+        version: link:../types
       '@lukeed/uuid':
         specifier: ^2.0.1
         version: 2.0.1
@@ -130,9 +130,9 @@ importers:
         specifier: ^1.9.4
         version: 1.9.4
     devDependencies:
-      '@anywidget/types':
-        specifier: workspace:^
-        version: link:../types
+      '@jupyter-widgets/base':
+        specifier: ^6
+        version: 6.0.10(react@19.0.0)
       '@jupyter-widgets/base-manager':
         specifier: ^1.0.11
         version: 1.0.11(react@19.0.0)


### PR DESCRIPTION
Fixes #811

In #670, `@anywidget/types` was inadvertently moved to `devDependencies`
for the `anywidget` npm package, causing it to no longer be installed
for users of `anywidget` and breaking imports from `anywidget/types`.

Since splitting our types into a separate package, we generally
encourage using `@anywidget/types` directly, allowing the
[AFM](https://anywidget.dev/en/afm) spec to be versioned independently
from the Python bindings/runtime. However, we can at least continue to
ship to avoid breaking builds.
