### PR TITLE
fix: use `RenderProps` instead of `RenderContext` in Vanilla TS template

### DIFF
--- a/.changeset/ready-bars-double.md
+++ b/.changeset/ready-bars-double.md
@@ -1,0 +1,5 @@
+---
+"create-anywidget": patch
+---
+
+Import `RenderProps` instead of `RenderContext` when scaffolding vanilla TS project

--- a/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/create-anywidget/__tests__/__snapshots__/index.test.js.snap
@@ -1107,7 +1107,7 @@ class Widget(anywidget.AnyWidget):
     "path": "src/ipyfoo/__init__.py",
   },
   {
-    "content": "import type { RenderContext } from "@anywidget/types";
+    "content": "import type { RenderProps } from "@anywidget/types";
 import "./widget.css";
 
 /* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
@@ -1116,7 +1116,7 @@ interface WidgetModel {
 	/* Add your own */
 }
 
-function render({ model, el }: RenderContext<WidgetModel>) {
+function render({ model, el }: RenderProps<WidgetModel>) {
 	let btn = document.createElement("button");
 	btn.innerHTML = \`count is \${model.get("value")}\`;
 	btn.addEventListener("click", () => {
@@ -2305,7 +2305,7 @@ class Widget(anywidget.AnyWidget):
     "path": "src/ipyfoo/__init__.py",
   },
   {
-    "content": "import type { RenderContext } from "@anywidget/types";
+    "content": "import type { RenderProps } from "@anywidget/types";
 import "./widget.css";
 
 /* Specifies attributes defined with traitlets in ../src/ipyfoo/__init__.py */
@@ -2314,7 +2314,7 @@ interface WidgetModel {
 	/* Add your own */
 }
 
-function render({ model, el }: RenderContext<WidgetModel>) {
+function render({ model, el }: RenderProps<WidgetModel>) {
 	let btn = document.createElement("button");
 	btn.innerHTML = \`count is \${model.get("value")}\`;
 	btn.addEventListener("click", () => {

--- a/packages/create-anywidget/create.js
+++ b/packages/create-anywidget/create.js
@@ -346,7 +346,7 @@ export default { render };
 /** @param {string} name */
 let widget_vanilla_ts = (name) =>
 	`\
-import type { RenderContext } from "@anywidget/types";
+import type { RenderProps } from "@anywidget/types";
 import "./widget.css";
 
 /* Specifies attributes defined with traitlets in ../src/${name}/__init__.py */
@@ -355,7 +355,7 @@ interface WidgetModel {
 	/* Add your own */
 }
 
-function render({ model, el }: RenderContext<WidgetModel>) {
+function render({ model, el }: RenderProps<WidgetModel>) {
 	let btn = document.createElement("button");
 	btn.innerHTML = \`count is \${model.get("value")}\`;
 	btn.addEventListener("click", () => {


### PR DESCRIPTION
Closes #820