### PR TITLE
fix(anywidget): Use temporary polyfill for `Promise.withResolvers`

### DIFF
--- a/.changeset/sixty-rules-turn.md
+++ b/.changeset/sixty-rules-turn.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+Fix: Use temporary polyfill for `Promise.withResolvers` for Safari compat

--- a/packages/anywidget/src/widget.js
+++ b/packages/anywidget/src/widget.js
@@ -301,6 +301,25 @@ export function invoke(model, name, msg, options = {}) {
 	});
 }
 
+/**
+ * Polyfill for {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers Promise.withResolvers}
+ *
+ * Trevor(2025-03-14): Should be able to remove once more stable across browsers.
+ *
+ * @template T
+ * @returns {PromiseWithResolvers<T>}
+ */
+function promise_with_resolvers() {
+	let resolve;
+	let reject;
+	let promise = new Promise((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	// @ts-expect-error - We know these types are ok
+	return { promise, resolve, reject };
+}
+
 class Runtime {
 	/** @type {() => void} */
 	#disposer = () => {};
@@ -315,7 +334,7 @@ class Runtime {
 	/** @param {base.DOMWidgetModel} model */
 	constructor(model) {
 		/** @type {PromiseWithResolvers<void>} */
-		const { promise, resolve } = Promise.withResolvers();
+		const { promise, resolve } = promise_with_resolvers();
 		this.ready = promise;
 		this.#disposer = solid.createRoot((dispose) => {
 			let [css, set_css] = solid.createSignal(model.get("_css"));


### PR DESCRIPTION
Fixes #823

Although now stabilized across all major browsers, it may take some time
for folks to upgrade. In the meantime, we can just have a simple utility
which we can eventually deprecate.
