### PR TITLE
refactor(anywidget): Mange frontend HMR runtimes with web `AbortController`

### DIFF
--- a/.changeset/floppy-otters-share.md
+++ b/.changeset/floppy-otters-share.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+Refactor: Manage front-end HMR runtimes with web `AbortController`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,4 +96,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           run_install: true
-      - run: pnpm test
+      - run: |
+          pnpm exec playwright install 
+          pnpm vitest --run

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"version": "changeset version",
 		"release": "pnpm build:packages && uv build && changeset publish && uvx twine upload --skip-existing dist/*",
 		"test": "vitest",
-		"typecheck": "tsc --build && vitest --typecheck.only --run",
+		"typecheck": "tsc --build",
 		"fix": "biome check --write .",
 		"publint": "pnpm --recursive --filter=\"./packages/**\" exec publint"
 	},
@@ -19,6 +19,7 @@
 		"@svitejs/changesets-changelog-github-compact": "^1.2.0",
 		"@vitest/browser": "^3.0.9",
 		"esbuild": "^0.25.1",
+		"playwright": "^1.51.1",
 		"publint": "^0.3.9",
 		"typescript": "^5.8.2",
 		"vitest": "^3.0.9"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"clean": "rm -rf dist anywidget/nbextension/index.js anywidget/labextension && pnpm -r exec rm -rf dist",
 		"version": "changeset version",
 		"release": "pnpm build:packages && uv build && changeset publish && uvx twine upload --skip-existing dist/*",
-		"test": "vitest --environment=happy-dom --run",
+		"test": "vitest",
 		"typecheck": "tsc --build && vitest --typecheck.only --run",
 		"fix": "biome check --write .",
 		"publint": "pnpm --recursive --filter=\"./packages/**\" exec publint"
@@ -17,8 +17,8 @@
 		"@rspack/cli": "^1.2.7",
 		"@rspack/core": "^1.2.7",
 		"@svitejs/changesets-changelog-github-compact": "^1.2.0",
+		"@vitest/browser": "^3.0.9",
 		"esbuild": "^0.25.1",
-		"happy-dom": "^17.4.4",
 		"publint": "^0.3.9",
 		"typescript": "^5.8.2",
 		"vitest": "^3.0.9"

--- a/package.json
+++ b/package.json
@@ -18,10 +18,16 @@
 		"@rspack/core": "^1.2.7",
 		"@svitejs/changesets-changelog-github-compact": "^1.2.0",
 		"esbuild": "^0.25.1",
-		"happy-dom": "^17.4.3",
+		"happy-dom": "^17.4.4",
 		"publint": "^0.3.9",
 		"typescript": "^5.8.2",
-		"vitest": "^3.0.8"
+		"vitest": "^3.0.9"
 	},
-	"packageManager": "pnpm@9.10.0"
+	"packageManager": "pnpm@9.10.0",
+	"pnpm": {
+		"patchedDependencies": {
+			"@jupyter-widgets/base": "patches/@jupyter-widgets__base.patch",
+			"@jupyter-widgets/base-manager": "patches/@jupyter-widgets__base-manager.patch"
+		}
+	}
 }

--- a/packages/anywidget/src/widget.js
+++ b/packages/anywidget/src/widget.js
@@ -321,22 +321,26 @@ function promise_with_resolvers() {
 }
 
 class Runtime {
-	/** @type {() => void} */
-	#disposer = () => {};
-	/** @type {Set<() => void>} */
-	#view_disposers = new Set();
 	/** @type {import('solid-js').Resource<Result<AnyWidget & { url: string }>>} */
 	// @ts-expect-error - Set synchronously in constructor.
 	#widget_result;
 	/** @type {Promise<void>} */
 	ready;
+	/** @type {AbortSignal} */
+	#signal;
 
-	/** @param {base.DOMWidgetModel} model */
-	constructor(model) {
+	/**
+	 * @param {base.DOMWidgetModel} model
+	 * @param {{ signal: AbortSignal }} options
+	 */
+	constructor(model, options) {
 		/** @type {PromiseWithResolvers<void>} */
-		const { promise, resolve } = promise_with_resolvers();
-		this.ready = promise;
-		this.#disposer = solid.createRoot((dispose) => {
+		const resolvers = promise_with_resolvers();
+		this.ready = resolvers.promise;
+		this.#signal = options.signal;
+		this.#signal.throwIfAborted();
+		this.#signal.addEventListener("abort", () => dispose());
+		let dispose = solid.createRoot((dispose) => {
 			let [css, set_css] = solid.createSignal(model.get("_css"));
 			model.on("change:_css", () => {
 				let id = model.get("_anywidget_id");
@@ -362,7 +366,7 @@ class Runtime {
 				try {
 					model.off(null, null, INITIALIZE_MARKER);
 					let widget = await load_widget(update, model.get("_anywidget_id"));
-					resolve();
+					resolvers.resolve();
 					cleanup = await widget.initialize?.({
 						model: model_proxy(model, INITIALIZE_MARKER),
 						experimental: {
@@ -386,11 +390,15 @@ class Runtime {
 
 	/**
 	 * @param {base.DOMWidgetView} view
-	 * @returns {Promise<() => void>}
+	 * @param {{ signal: AbortSignal }} options
+	 * @returns {Promise<void>}
 	 */
-	async create_view(view) {
+	async create_view(view, options) {
 		let model = view.model;
-		let disposer = solid.createRoot((dispose) => {
+		let signal = AbortSignal.any([this.#signal, options.signal]); // either model or view destroyed
+		signal.throwIfAborted();
+		signal.addEventListener("abort", () => dispose());
+		let dispose = solid.createRoot((dispose) => {
 			/** @type {void | (() => Awaitable<void>)} */
 			let cleanup;
 			let resource = solid.createResource(
@@ -428,19 +436,6 @@ class Runtime {
 				cleanup?.();
 			};
 		});
-		// Have the runtime keep track but allow the view to dispose itself.
-		this.#view_disposers.add(disposer);
-		return () => {
-			let deleted = this.#view_disposers.delete(disposer);
-			if (deleted) disposer();
-		};
-	}
-
-	dispose() {
-		// biome-ignore lint/complexity/noForEach: Easier to read than a for loop.
-		this.#view_disposers.forEach((dispose) => dispose());
-		this.#view_disposers.clear();
-		this.#disposer();
 	}
 }
 
@@ -467,10 +462,11 @@ export default function ({ DOMWidgetModel, DOMWidgetView }) {
 		/** @param {Parameters<InstanceType<DOMWidgetModel>["initialize"]>} args */
 		initialize(...args) {
 			super.initialize(...args);
-			let runtime = new Runtime(this);
+			let controller = new AbortController();
+			let runtime = new Runtime(this, { signal: controller.signal });
 			this.once("destroy", () => {
 				try {
-					runtime.dispose();
+					controller.abort("[anywidget] Runtime destroyed.");
 				} finally {
 					RUNTIMES.delete(this);
 				}
@@ -520,16 +516,14 @@ export default function ({ DOMWidgetModel, DOMWidgetView }) {
 	}
 
 	class AnyView extends DOMWidgetView {
-		/** @type {undefined | (() => void)} */
-		#dispose = undefined;
+		#controller = new AbortController();
 		async render() {
 			let runtime = RUNTIMES.get(this.model);
-			assert(runtime, "[anywidget] runtime not found.");
-			assert(!this.#dispose, "[anywidget] dispose already set.");
-			this.#dispose = await runtime.create_view(this);
+			assert(runtime, "[anywidget] Runtime not found.");
+			await runtime.create_view(this, { signal: this.#controller.signal });
 		}
 		remove() {
-			this.#dispose?.();
+			this.#controller.abort("[anywidget] View destroyed.");
 			super.remove();
 		}
 	}

--- a/packages/anywidget/src/widget.js
+++ b/packages/anywidget/src/widget.js
@@ -107,12 +107,12 @@ async function load_css(css, anywidget_id) {
 async function load_esm(esm) {
 	if (is_href(esm)) {
 		return {
-			mod: await import(/* webpackIgnore: true */ esm),
+			mod: await import(/* webpackIgnore: true */ /* @vite-ignore */ esm),
 			url: esm,
 		};
 	}
 	let url = URL.createObjectURL(new Blob([esm], { type: "text/javascript" }));
-	let mod = await import(/* webpackIgnore: true */ url);
+	let mod = await import(/* webpackIgnore: true */ /* @vite-ignore */ url);
 	URL.revokeObjectURL(url);
 	return { mod, url };
 }

--- a/patches/@jupyter-widgets__base-manager.patch
+++ b/patches/@jupyter-widgets__base-manager.patch
@@ -1,0 +1,78 @@
+diff --git a/lib/index.d.ts b/lib/index.d.ts
+index 6121d55b3f73ebf648c599f100cbd9f953e81c62..fa2b457aa6b2ec4ecb1ecf4ba1f8791ac015f902 100644
+--- a/lib/index.d.ts
++++ b/lib/index.d.ts
+@@ -1,3 +1,2 @@
+ export * from './manager-base';
+ export * from './utils';
+-//# sourceMappingURL=index.d.ts.map
+\ No newline at end of file
+diff --git a/lib/index.js b/lib/index.js
+index c1a2620f397408ded4eb2c282a79eada26ea02f7..97b5da7a5c5b44092b119263fe4d4836187852cb 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -2,4 +2,3 @@
+ // Distributed under the terms of the Modified BSD License.
+ export * from './manager-base';
+ export * from './utils';
+-//# sourceMappingURL=index.js.map
+\ No newline at end of file
+diff --git a/lib/latex.d.ts b/lib/latex.d.ts
+index da15e3cb21bbd25ac3c50f5ac02e3f4b1ae401d4..10653313d1f679c68e0d7a3b46af47d592623e58 100644
+--- a/lib/latex.d.ts
++++ b/lib/latex.d.ts
+@@ -14,4 +14,3 @@ export declare function removeMath(text: string): {
+  * and clear the math array (no need to keep it around).
+  */
+ export declare function replaceMath(text: string, math: string[]): string;
+-//# sourceMappingURL=latex.d.ts.map
+\ No newline at end of file
+diff --git a/lib/latex.js b/lib/latex.js
+index 12c5c8b4a3efdb890855a36c4e33662f32ebba34..7648dc6827ee8523b8cd3b7dfa109fd7492ac236 100644
+--- a/lib/latex.js
++++ b/lib/latex.js
+@@ -178,4 +178,3 @@ function processMath(i, j, preProcess, math, blocks) {
+     math.push(block);
+     return blocks;
+ }
+-//# sourceMappingURL=latex.js.map
+\ No newline at end of file
+diff --git a/lib/manager-base.d.ts b/lib/manager-base.d.ts
+index 6e3781af6d3fba8c204d6927b6652b6486b73e78..b65f48daad8d0021e52ff804ee04f8c2b7443726 100644
+--- a/lib/manager-base.d.ts
++++ b/lib/manager-base.d.ts
+@@ -219,4 +219,3 @@ export interface IStateOptions {
+  * @jupyter-widgets/schema package.
+  */
+ export declare function serialize_state(models: WidgetModel[], options?: IStateOptions): IManagerState;
+-//# sourceMappingURL=manager-base.d.ts.map
+\ No newline at end of file
+diff --git a/lib/manager-base.js b/lib/manager-base.js
+index 6f39504b4521aa0f69852b003aa3a5aa1d8874f8..80d0628062ec7d818ceff5167d899426dd82f93a 100644
+--- a/lib/manager-base.js
++++ b/lib/manager-base.js
+@@ -638,4 +638,3 @@ export function serialize_state(models, options = {}) {
+     });
+     return { version_major: 2, version_minor: 0, state: state };
+ }
+-//# sourceMappingURL=manager-base.js.map
+\ No newline at end of file
+diff --git a/lib/utils.d.ts b/lib/utils.d.ts
+index a0b3000da24273494c72442ee0c88e654577324a..6d9397b74eb9adac68500f70076c589371065d24 100644
+--- a/lib/utils.d.ts
++++ b/lib/utils.d.ts
+@@ -14,4 +14,3 @@ export declare function bufferToBase64(buffer: ArrayBuffer): string;
+  * Convert a base64 string to an ArrayBuffer.
+  */
+ export declare function base64ToBuffer(base64: string): ArrayBuffer;
+-//# sourceMappingURL=utils.d.ts.map
+\ No newline at end of file
+diff --git a/lib/utils.js b/lib/utils.js
+index 858eab259290e5aaab57a8c1bc2add0fec1b9218..00c1c55acd1b84e43552de4144bb46d01fa2c70c 100644
+--- a/lib/utils.js
++++ b/lib/utils.js
+@@ -292,4 +292,3 @@ export function bufferToBase64(buffer) {
+ export function base64ToBuffer(base64) {
+     return toByteArray(base64).buffer;
+ }
+-//# sourceMappingURL=utils.js.map

--- a/patches/@jupyter-widgets__base-manager.patch
+++ b/patches/@jupyter-widgets__base-manager.patch
@@ -48,10 +48,22 @@ index 6e3781af6d3fba8c204d6927b6652b6486b73e78..b65f48daad8d0021e52ff804ee04f8c2
 -//# sourceMappingURL=manager-base.d.ts.map
 \ No newline at end of file
 diff --git a/lib/manager-base.js b/lib/manager-base.js
-index 6f39504b4521aa0f69852b003aa3a5aa1d8874f8..80d0628062ec7d818ceff5167d899426dd82f93a 100644
+index 6f39504b4521aa0f69852b003aa3a5aa1d8874f8..33ed5f7a33221828c8869f81cd8b71dacd0e2a30 100644
 --- a/lib/manager-base.js
 +++ b/lib/manager-base.js
-@@ -638,4 +638,3 @@ export function serialize_state(models, options = {}) {
+@@ -1,11 +1,9 @@
+ // Copyright (c) Jupyter Development Team.
+ // Distributed under the terms of the Modified BSD License.
+ import * as widgets from '@jupyter-widgets/base';
+-import { PromiseDelegate, } from '@lumino/coreutils';
+ import { put_buffers, remove_buffers, resolvePromisesDict, reject, uuid, PROTOCOL_VERSION, } from '@jupyter-widgets/base';
+ import { base64ToBuffer, bufferToBase64, hexToBuffer } from './utils';
+ import { removeMath, replaceMath } from './latex';
+-import sanitize from 'sanitize-html';
+ const PROTOCOL_MAJOR_VERSION = PROTOCOL_VERSION.split('.', 1)[0];
+ /**
+  * The control comm target name.
+@@ -638,4 +636,3 @@ export function serialize_state(models, options = {}) {
      });
      return { version_major: 2, version_minor: 0, state: state };
  }

--- a/patches/@jupyter-widgets__base.patch
+++ b/patches/@jupyter-widgets__base.patch
@@ -1,0 +1,258 @@
+diff --git a/lib/backbone-patch.d.ts b/lib/backbone-patch.d.ts
+index 26dc9c4343535e107acb38f5aec13461e081f810..2d40cbf516a54e1be4ddf7331072ed611dee252e 100644
+--- a/lib/backbone-patch.d.ts
++++ b/lib/backbone-patch.d.ts
+@@ -2,4 +2,3 @@ import { ModelSetOptions } from 'backbone';
+ export declare function set(key: string | {}, val: any, options: ModelSetOptions & {
+     unset?: boolean;
+ }): any;
+-//# sourceMappingURL=backbone-patch.d.ts.map
+\ No newline at end of file
+diff --git a/lib/backbone-patch.js b/lib/backbone-patch.js
+index e785d73e4d32223901faa391f18cd031ed2bad9c..8b70dd99aa7a6213541c513ec118d0d33966ac93 100644
+--- a/lib/backbone-patch.js
++++ b/lib/backbone-patch.js
+@@ -115,4 +115,3 @@ export function set(key, val, options) {
+     }
+     return this;
+ }
+-//# sourceMappingURL=backbone-patch.js.map
+\ No newline at end of file
+diff --git a/lib/errorwidget.d.ts b/lib/errorwidget.d.ts
+index 9c4432de2a4932e3d60394b6dd9c64cf003971a5..234bd2a646f56c83652a43198c13ba831f080fab 100644
+--- a/lib/errorwidget.d.ts
++++ b/lib/errorwidget.d.ts
+@@ -8,4 +8,3 @@ export declare class ErrorWidgetView extends DOMWidgetView {
+     render(): void;
+ }
+ export declare function createErrorWidgetView(error?: unknown, msg?: string): typeof WidgetView;
+-//# sourceMappingURL=errorwidget.d.ts.map
+\ No newline at end of file
+diff --git a/lib/errorwidget.js b/lib/errorwidget.js
+index d3218b49c10d3b1b5417a6da87e880e0f45f6bf8..ce7c46c66540f078ce9540ffa9b47f596deb3538 100644
+--- a/lib/errorwidget.js
++++ b/lib/errorwidget.js
+@@ -65,4 +65,3 @@ export function createErrorWidgetView(error, msg) {
+         }
+     };
+ }
+-//# sourceMappingURL=errorwidget.js.map
+\ No newline at end of file
+diff --git a/lib/index.d.ts b/lib/index.d.ts
+index 446c0112f116992f1f66f06e5974708f12959b17..6942b31968d224d64b452fb286e4c245ff6a165c 100644
+--- a/lib/index.d.ts
++++ b/lib/index.d.ts
+@@ -8,4 +8,3 @@ export * from './version';
+ export * from './utils';
+ export * from './registry';
+ export * from './errorwidget';
+-//# sourceMappingURL=index.d.ts.map
+\ No newline at end of file
+diff --git a/lib/index.js b/lib/index.js
+index 086cad737a4721935e251d74aa54bdce8225d126..f07fca97df8338f2e95dd1686e165249b3887b99 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -10,4 +10,3 @@ export * from './version';
+ export * from './utils';
+ export * from './registry';
+ export * from './errorwidget';
+-//# sourceMappingURL=index.js.map
+\ No newline at end of file
+diff --git a/lib/manager.d.ts b/lib/manager.d.ts
+index 3a03b374382d1b6fd0ab055454ad91097ada7078..c0737f4c4fb916d5cd060b304a8554dfc6c1126d 100644
+--- a/lib/manager.d.ts
++++ b/lib/manager.d.ts
+@@ -154,4 +154,3 @@ export interface IWidgetManager {
+     resolveUrl(url: string): Promise<string>;
+     inline_sanitize(s: string): string;
+ }
+-//# sourceMappingURL=manager.d.ts.map
+\ No newline at end of file
+diff --git a/lib/manager.js b/lib/manager.js
+index 0ceacd84e1d7f14becdd39146774dfca7d00cb1e..7d6aca72b4627c122a014fa7922652fb76c89b48 100644
+--- a/lib/manager.js
++++ b/lib/manager.js
+@@ -1,4 +1,3 @@
+ // Copyright (c) Jupyter Development Team.
+ // Distributed under the terms of the Modified BSD License.
+ export {};
+-//# sourceMappingURL=manager.js.map
+\ No newline at end of file
+diff --git a/lib/nativeview.d.ts b/lib/nativeview.d.ts
+index 1e37313889a485ff6ced0846f94336d3faa8dd63..68371363a1cc30bf67be32a7b00c9a2889308a25 100644
+--- a/lib/nativeview.d.ts
++++ b/lib/nativeview.d.ts
+@@ -24,4 +24,3 @@ export declare class NativeView<T extends Backbone.Model> extends Backbone.View<
+     undelegateEvents(): this;
+     private _domEvents;
+ }
+-//# sourceMappingURL=nativeview.d.ts.map
+\ No newline at end of file
+diff --git a/lib/nativeview.js b/lib/nativeview.js
+index cc997f73f08c6a0dba6516d7445c45eb3ce2b1fa..f1522bbe357ba74a0eabbbb500c5f136c16c29c0 100644
+--- a/lib/nativeview.js
++++ b/lib/nativeview.js
+@@ -137,4 +137,3 @@ export class NativeView extends Backbone.View {
+         return this;
+     }
+ }
+-//# sourceMappingURL=nativeview.js.map
+\ No newline at end of file
+diff --git a/lib/registry.d.ts b/lib/registry.d.ts
+index ee752ff1ef3c15f8a05523f40c31bcd0e15211f1..0781e5d1ef8662b85dab200baab269878be7a82d 100644
+--- a/lib/registry.d.ts
++++ b/lib/registry.d.ts
+@@ -34,4 +34,3 @@ export interface IWidgetRegistryData {
+      */
+     exports: ExportData;
+ }
+-//# sourceMappingURL=registry.d.ts.map
+\ No newline at end of file
+diff --git a/lib/registry.js b/lib/registry.js
+index 073a2b31e7360c884579a2b0d84b27fe8175fd89..52fb357597800f49f8298dba96019db571b4f013 100644
+--- a/lib/registry.js
++++ b/lib/registry.js
+@@ -5,4 +5,3 @@ import { Token } from '@lumino/coreutils';
+  * A runtime interface token for a widget registry.
+  */
+ export const IJupyterWidgetRegistry = new Token('jupyter.extensions.jupyterWidgetRegistry');
+-//# sourceMappingURL=registry.js.map
+\ No newline at end of file
+diff --git a/lib/services-shim.d.ts b/lib/services-shim.d.ts
+index a10a48535baf1e2efce593d46d74024224556d12..485fa455d1371afc039bd6f1d078b6be997b6bcd 100644
+--- a/lib/services-shim.d.ts
++++ b/lib/services-shim.d.ts
+@@ -166,4 +166,3 @@ export declare namespace shims {
+         }
+     }
+ }
+-//# sourceMappingURL=services-shim.d.ts.map
+\ No newline at end of file
+diff --git a/lib/services-shim.js b/lib/services-shim.js
+index 7f985cfbc6a39dda1eb8b348ffe7ecbe8d054be6..79594c935c1afd4274d38bd68c7a91e06fd66b9d 100644
+--- a/lib/services-shim.js
++++ b/lib/services-shim.js
+@@ -193,4 +193,3 @@ export var shims;
+         services.Comm = Comm;
+     })(services = shims.services || (shims.services = {}));
+ })(shims || (shims = {}));
+-//# sourceMappingURL=services-shim.js.map
+\ No newline at end of file
+diff --git a/lib/utils.d.ts b/lib/utils.d.ts
+index 300b56038665697d8b7af76dbee57f9dcb214fe9..4a91d6868615b2829026c7a2cacea58081472ece 100644
+--- a/lib/utils.d.ts
++++ b/lib/utils.d.ts
+@@ -72,4 +72,3 @@ export declare function isObject(data: BufferJSON): data is Dict<BufferJSON>;
+  */
+ export declare function remove_buffers(state: BufferJSON | ISerializeable): ISerializedState;
+ export declare const BROKEN_FILE_SVG_ICON = "<svg style=\"height:50%;max-height: 50px;\" role=\"img\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 48 48\">\n<g >\n  <g transform=\"translate(0.24520123,0.93464292)\">\n    <path  d=\"M 8.2494641,21.074514 V 5.6225142 c 0,-0.314 0.254,-0.567 0.57,-0.567 H 29.978464 c 2.388,0 9.268,5.8269998 9.268,8.3029998 v 5.5835 l -3.585749,4.407396 -2.772971,-3.535534 -5.126524,3.414213 -5.944543,-3.237436 -5.722718,3.06066 z m 30.9969999,3.8675 v 15.5835 c 0,0.314 -0.254,0.567 -0.57,0.567 H 8.8194641 c -0.315,0.002 -0.57,-0.251 -0.57,-0.566 v -15.452 l 7.8444949,2.628449 5.656854,-2.65165 4.24264,3.005204 5.833631,-3.237437 3.712311,3.944543 z\" style=\"fill:url(#linearGradient3448);stroke:#888a85\"  />\n    <path d=\"m 30.383464,12.110514 c 4.108,0.159 7.304,-0.978 8.867,1.446 0.304,-3.9679998 -7.254,-8.8279998 -9.285,-8.4979998 0.813,0.498 0.418,7.0519998 0.418,7.0519998 z\" style=\"fill:url(#linearGradient3445);stroke:#868a84\" />\n    <path enable-background=\"new\" d=\"m 31.443464,11.086514 c 2.754,-0.019 4.106,-0.49 5.702,0.19 -1.299,-1.8809998 -4.358,-3.3439998 -5.728,-4.0279998 0.188,0.775 0.026,3.8379998 0.026,3.8379998 z\" style=\"opacity:0.36930003;fill:none;stroke:url(#linearGradient3442)\" />\n  </g>\n</g>\n</svg>";
+-//# sourceMappingURL=utils.d.ts.map
+\ No newline at end of file
+diff --git a/lib/utils.js b/lib/utils.js
+index 9064bbb3c6e4a4bf761dd5cdd1ec1fc47ef7f679..3f84907996dcbc5c0da616c302660cef91708ef3 100644
+--- a/lib/utils.js
++++ b/lib/utils.js
+@@ -199,4 +199,3 @@ export const BROKEN_FILE_SVG_ICON = `<svg style="height:50%;max-height: 50px;" r
+   </g>
+ </g>
+ </svg>`;
+-//# sourceMappingURL=utils.js.map
+\ No newline at end of file
+diff --git a/lib/version.d.ts b/lib/version.d.ts
+index af968f610672919eeaca3da91184e6d901878767..840d737a3900bda3219ec540de96eba04029a4e8 100644
+--- a/lib/version.d.ts
++++ b/lib/version.d.ts
+@@ -1,3 +1,2 @@
+ export declare const JUPYTER_WIDGETS_VERSION = "2.0.0";
+ export declare const PROTOCOL_VERSION = "2.1.0";
+-//# sourceMappingURL=version.d.ts.map
+\ No newline at end of file
+diff --git a/lib/version.js b/lib/version.js
+index 21bb87e9bddcbc92f43189d0059df640b05260be..a60215ad1fd8cb20e905ab9909448e4a00412bc0 100644
+--- a/lib/version.js
++++ b/lib/version.js
+@@ -2,4 +2,3 @@
+ // Distributed under the terms of the Modified BSD License.
+ export const JUPYTER_WIDGETS_VERSION = '2.0.0';
+ export const PROTOCOL_VERSION = '2.1.0';
+-//# sourceMappingURL=version.js.map
+\ No newline at end of file
+diff --git a/lib/viewlist.d.ts b/lib/viewlist.d.ts
+index 0eddea91cc0f2400e6c1fa61d251acbcae5a4a7c..286350a51528c96282269aee7df4622b86fe91a6 100644
+--- a/lib/viewlist.d.ts
++++ b/lib/viewlist.d.ts
+@@ -42,4 +42,3 @@ export declare class ViewList<T> {
+     _create_view: (model: any, index: any) => T | Promise<T>;
+     _remove_view: (view: T) => void;
+ }
+-//# sourceMappingURL=viewlist.d.ts.map
+\ No newline at end of file
+diff --git a/lib/viewlist.js b/lib/viewlist.js
+index d1f26b23d2c02dac5d306a760d26c286803fe5ec..97e0f64bcc87c66df0eaa1cf405c77d133d228af 100644
+--- a/lib/viewlist.js
++++ b/lib/viewlist.js
+@@ -87,4 +87,3 @@ export class ViewList {
+         this._models = null;
+     }
+ }
+-//# sourceMappingURL=viewlist.js.map
+\ No newline at end of file
+diff --git a/lib/widget.d.ts b/lib/widget.d.ts
+index 74c8d91bba1ed2db863ee022e6c681c7e6db5b08..b72edc0738a4829da4ff944588010bb98333ba3a 100644
+--- a/lib/widget.d.ts
++++ b/lib/widget.d.ts
+@@ -363,4 +363,3 @@ export declare class DOMWidgetView extends WidgetView {
+     layoutPromise: Promise<any>;
+     stylePromise: Promise<any>;
+ }
+-//# sourceMappingURL=widget.d.ts.map
+\ No newline at end of file
+diff --git a/lib/widget.js b/lib/widget.js
+index 3cf3f2139e63ccdc3f2c5f71051032146b6922fb..54fd543190784ce798902f46b022fcaa0e228a92 100644
+--- a/lib/widget.js
++++ b/lib/widget.js
+@@ -984,4 +984,3 @@ export class DOMWidgetView extends WidgetView {
+         this.luminoWidget = value;
+     }
+ }
+-//# sourceMappingURL=widget.js.map
+\ No newline at end of file
+diff --git a/lib/widget_layout.d.ts b/lib/widget_layout.d.ts
+index 9d1619f17574967a14552f2afbc854d680a02e0e..0025005bb5ce7e2425ce36f05efe7c9185b7accd 100644
+--- a/lib/widget_layout.d.ts
++++ b/lib/widget_layout.d.ts
+@@ -29,4 +29,3 @@ export declare class LayoutView extends WidgetView {
+     unlayout(): void;
+     private _traitNames;
+ }
+-//# sourceMappingURL=widget_layout.d.ts.map
+\ No newline at end of file
+diff --git a/lib/widget_layout.js b/lib/widget_layout.js
+index 7c2a6257eea7498293b110c8870fc477a3fc6b4b..5e46122750f3fcec84d19212a92adc7d832932bd 100644
+--- a/lib/widget_layout.js
++++ b/lib/widget_layout.js
+@@ -123,4 +123,3 @@ export class LayoutView extends WidgetView {
+         }, this);
+     }
+ }
+-//# sourceMappingURL=widget_layout.js.map
+\ No newline at end of file
+diff --git a/lib/widget_style.d.ts b/lib/widget_style.d.ts
+index c7977113ce758a8dd1d83772c4f4be36d7bea5f2..5576ed0535ac943a0524513ebcb4e4add8669bed 100644
+--- a/lib/widget_style.d.ts
++++ b/lib/widget_style.d.ts
+@@ -40,4 +40,3 @@ export declare class StyleView extends WidgetView {
+     private _traitNames;
+ }
+ export {};
+-//# sourceMappingURL=widget_style.d.ts.map
+\ No newline at end of file
+diff --git a/lib/widget_style.js b/lib/widget_style.js
+index eab3336e20f932adc3b4163cdaca7f53a3b1fc14..4176e51f8b8611d543ffff3babb479e5f7a1552a 100644
+--- a/lib/widget_style.js
++++ b/lib/widget_style.js
+@@ -106,4 +106,3 @@ export class StyleView extends WidgetView {
+         }, this);
+     }
+ }
+-//# sourceMappingURL=widget_style.js.map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,12 +31,12 @@ importers:
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.2.0
         version: 1.2.0
+      '@vitest/browser':
+        specifier: ^3.0.9
+        version: 3.0.9(@types/node@22.13.10)(typescript@5.8.2)(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))(vitest@3.0.9)
       esbuild:
         specifier: ^0.25.1
         version: 0.25.1
-      happy-dom:
-        specifier: ^17.4.4
-        version: 17.4.4
       publint:
         specifier: ^0.3.9
         version: 0.3.9
@@ -45,7 +45,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^3.0.9
-        version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.10)(happy-dom@17.4.4)(jiti@1.21.7)(yaml@2.7.0)
+        version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.9)(happy-dom@17.4.4)(jiti@1.21.7)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))(yaml@2.7.0)
 
   docs:
     dependencies:
@@ -552,6 +552,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@bundled-es-modules/cookie@2.0.1':
+    resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
+
+  '@bundled-es-modules/statuses@1.0.1':
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
+
   '@changesets/apply-release-plan@7.0.10':
     resolution: {integrity: sha512-wNyeIJ3yDsVspYvHnEz1xQDq18D9ifed3lI+wxRQRK4pArUcuHgCTrHv0QRnnwjhVCQACxZ+CBih3wgOct6UXw==}
 
@@ -1057,6 +1066,37 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/confirm@5.1.8':
+    resolution: {integrity: sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.1.9':
+    resolution: {integrity: sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.11':
+    resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.5':
+    resolution: {integrity: sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1209,6 +1249,10 @@ packages:
   '@module-federation/webpack-bundler-runtime@0.8.4':
     resolution: {integrity: sha512-HggROJhvHPUX7uqBD/XlajGygMNM1DG0+4OAkk8MBQe4a18QzrRNzZt6XQbRTSG4OaEoyRWhQHvYD3Yps405tQ==}
 
+  '@mswjs/interceptors@0.37.6':
+    resolution: {integrity: sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==}
+    engines: {node: '>=18'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1220,6 +1264,15 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -1490,8 +1543,21 @@ packages:
     resolution: {integrity: sha512-08eKiDAjj4zLug1taXSIJ0kGL5cawjVCyJkBb6EWSg5fEPX6L+Wtr0CH2If4j5KYylz85iaZiFlUItvgJvll5g==}
     engines: {node: ^14.13.1 || ^16.0.0 || >=18}
 
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1641,6 +1707,12 @@ packages:
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
 
+  '@types/statuses@2.0.5':
+    resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
   '@types/underscore@1.13.0':
     resolution: {integrity: sha512-L6LBgy1f0EFQZ+7uSA57+n2g/s4Qs5r06Vwrwn0/nuK1de+adz00NWaztRQ30aEqw5qOaWbPI8u2cGQ52lj6VA==}
 
@@ -1661,6 +1733,21 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
+
+  '@vitest/browser@3.0.9':
+    resolution: {integrity: sha512-P9dcCeMkA3/oYGfUzRFZJLZxiOpApztxhPsQDUiZzAzLoZonWhse2+vPB0xEBP8Q0lX1WCEEmtY7HzBRi4oYBA==}
+    peerDependencies:
+      playwright: '*'
+      safaridriver: '*'
+      vitest: 3.0.9
+      webdriverio: ^7.0.0 || ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
 
   '@vitest/expect@3.0.9':
     resolution: {integrity: sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==}
@@ -1762,6 +1849,10 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-html-community@0.0.8:
     resolution: {integrity: sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==}
     engines: {'0': node >= 0.8.0}
@@ -1782,6 +1873,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -1801,6 +1896,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1989,6 +2087,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2195,6 +2297,9 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2519,6 +2624,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  graphql@16.10.0:
+    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
@@ -2585,6 +2694,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
@@ -2731,6 +2843,9 @@ packages:
   is-network-error@1.1.0:
     resolution: {integrity: sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==}
     engines: {node: '>=16'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -2914,6 +3029,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -3175,12 +3294,26 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.7.3:
+    resolution: {integrity: sha512-+mycXv8l2fEAjFZ5sjrtjJDmm2ceKGjrNbBr1durRg6VkU9fNUE/gsmQ51hWbHqs+l35W1iM+ZsmOD9Fd6lspw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
   multicast-dns@7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -3292,6 +3425,9 @@ packages:
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -3374,6 +3510,9 @@ packages:
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3476,6 +3615,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -3497,10 +3640,17 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   publint@0.3.9:
     resolution: {integrity: sha512-irTwfRfYW38vomkxxoiZQtFtUOQKpz5m0p9Z60z4xpXrl1KmvSrX1OMARvnnolB5usOXeNfvLj6d/W3rwXKfBQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -3532,6 +3682,9 @@ packages:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -3833,6 +3986,10 @@ packages:
     resolution: {integrity: sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==}
     engines: {node: '>= 10'}
 
+  sirv@3.0.1:
+    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -3899,6 +4056,9 @@ packages:
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -4023,6 +4183,14 @@ packages:
     resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
     engines: {node: '>=6'}
 
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -4053,6 +4221,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
 
   type-fest@4.37.0:
     resolution: {integrity: sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==}
@@ -4120,6 +4292,10 @@ packages:
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
 
   unpipe@1.0.0:
@@ -4475,6 +4651,10 @@ packages:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
     engines: {node: '>=18'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -4555,6 +4735,10 @@ packages:
   yocto-queue@1.2.0:
     resolution: {integrity: sha512-KHBC7z61OJeaMGnF3wqNZj+GGNXOyypZviiKpQeiHirG5Ib1ImwcLBH70rbMSkKfSmUNBsdf2PwaEJtKvgmkNw==}
     engines: {node: '>=12.20'}
+
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
 
   zimmerframe@1.1.2:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
@@ -5048,6 +5232,19 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
+  '@bundled-es-modules/cookie@2.0.1':
+    dependencies:
+      cookie: 0.7.2
+
+  '@bundled-es-modules/statuses@1.0.1':
+    dependencies:
+      statuses: 2.0.1
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    dependencies:
+      '@types/tough-cookie': 4.0.5
+      tough-cookie: 4.1.4
+
   '@changesets/apply-release-plan@7.0.10':
     dependencies:
       '@changesets/config': 3.1.1
@@ -5473,6 +5670,32 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
+  '@inquirer/confirm@5.1.8(@types/node@22.13.10)':
+    dependencies:
+      '@inquirer/core': 10.1.9(@types/node@22.13.10)
+      '@inquirer/type': 3.0.5(@types/node@22.13.10)
+    optionalDependencies:
+      '@types/node': 22.13.10
+
+  '@inquirer/core@10.1.9(@types/node@22.13.10)':
+    dependencies:
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.5(@types/node@22.13.10)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.13.10
+
+  '@inquirer/figures@1.0.11': {}
+
+  '@inquirer/type@3.0.5(@types/node@22.13.10)':
+    optionalDependencies:
+      '@types/node': 22.13.10
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -5759,6 +5982,15 @@ snapshots:
       '@module-federation/runtime': 0.8.4
       '@module-federation/sdk': 0.8.4
 
+  '@mswjs/interceptors@0.37.6':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5770,6 +6002,15 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -6041,9 +6282,26 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@testing-library/dom@10.4.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/runtime': 7.26.9
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.6
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -6224,6 +6482,10 @@ snapshots:
     dependencies:
       '@types/node': 22.13.10
 
+  '@types/statuses@2.0.5': {}
+
+  '@types/tough-cookie@4.0.5': {}
+
   '@types/underscore@1.13.0': {}
 
   '@types/unist@2.0.11': {}
@@ -6247,6 +6509,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/browser@3.0.9(@types/node@22.13.10)(typescript@5.8.2)(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))(vitest@3.0.9)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.0.9(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))
+      '@vitest/utils': 3.0.9
+      magic-string: 0.30.17
+      msw: 2.7.3(@types/node@22.13.10)(typescript@5.8.2)
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.9)(happy-dom@17.4.4)(jiti@1.21.7)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))(yaml@2.7.0)
+      ws: 8.18.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vite
+
   '@vitest/expect@3.0.9':
     dependencies:
       '@vitest/spy': 3.0.9
@@ -6254,12 +6535,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.9(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.9(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
+      msw: 2.7.3(@types/node@22.13.10)(typescript@5.8.2)
       vite: 6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.0.9':
@@ -6390,6 +6672,10 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-html-community@0.0.8: {}
 
   ansi-regex@5.0.1: {}
@@ -6401,6 +6687,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
 
@@ -6418,6 +6706,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -6677,6 +6969,8 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
+  cli-width@4.1.0: {}
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -6848,6 +7142,8 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -7250,6 +7546,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  graphql@16.10.0: {}
+
   gray-matter@4.0.3:
     dependencies:
       js-yaml: 3.14.1
@@ -7267,6 +7565,7 @@ snapshots:
     dependencies:
       webidl-conversions: 7.0.0
       whatwg-mimetype: 3.0.0
+    optional: true
 
   has-flag@4.0.0: {}
 
@@ -7406,6 +7705,8 @@ snapshots:
 
   he@1.2.0: {}
 
+  headers-polyfill@4.0.3: {}
+
   hpack.js@2.1.6:
     dependencies:
       inherits: 2.0.4
@@ -7533,6 +7834,8 @@ snapshots:
   is-interactive@2.0.0: {}
 
   is-network-error@1.1.0: {}
+
+  is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
 
@@ -7677,6 +7980,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -8189,12 +8494,39 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@bundled-es-modules/tough-cookie': 0.1.6
+      '@inquirer/confirm': 5.1.8(@types/node@22.13.10)
+      '@mswjs/interceptors': 0.37.6
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      graphql: 16.10.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.37.0
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   muggle-string@0.4.1: {}
 
   multicast-dns@7.2.5:
     dependencies:
       dns-packet: 5.6.1
       thunky: 1.1.0
+
+  mute-stream@2.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -8292,6 +8624,8 @@ snapshots:
 
   outdent@0.5.0: {}
 
+  outvariant@1.4.3: {}
+
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -8378,6 +8712,8 @@ snapshots:
 
   path-to-regexp@0.1.12: {}
 
+  path-to-regexp@6.3.0: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
@@ -8454,6 +8790,12 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prismjs@1.30.0: {}
 
   process-nextick-args@2.0.1: {}
@@ -8472,12 +8814,18 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   publint@0.3.9:
     dependencies:
       '@publint/pack': 0.1.2
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       sade: 1.8.1
+
+  punycode@2.3.1: {}
 
   qs@6.13.0:
     dependencies:
@@ -8508,6 +8856,8 @@ snapshots:
     dependencies:
       react: 19.0.0
       scheduler: 0.25.0
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -8964,6 +9314,12 @@ snapshots:
       mrmime: 1.0.1
       totalist: 1.1.0
 
+  sirv@3.0.1:
+    dependencies:
+      '@polka/url': 1.0.0-next.28
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   sitemap@8.0.0:
@@ -9034,6 +9390,8 @@ snapshots:
   stdin-discarder@0.2.2: {}
 
   stream-replace-string@2.0.0: {}
+
+  strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -9186,6 +9544,15 @@ snapshots:
 
   totalist@1.1.0: {}
 
+  totalist@3.0.1: {}
+
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tr46@0.0.3: {}
 
   tree-dump@1.0.2(tslib@2.8.1):
@@ -9203,6 +9570,8 @@ snapshots:
       typescript: 5.8.2
 
   tslib@2.8.1: {}
+
+  type-fest@0.21.3: {}
 
   type-fest@4.37.0: {}
 
@@ -9284,6 +9653,8 @@ snapshots:
       unist-util-visit-parents: 6.0.1
 
   universalify@0.1.2: {}
+
+  universalify@0.2.0: {}
 
   unpipe@1.0.0: {}
 
@@ -9381,10 +9752,10 @@ snapshots:
     optionalDependencies:
       vite: 5.4.14(@types/node@18.19.80)
 
-  vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.13.10)(happy-dom@17.4.4)(jiti@1.21.7)(yaml@2.7.0):
+  vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.9)(happy-dom@17.4.4)(jiti@1.21.7)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.9(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -9406,6 +9777,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.13.10
+      '@vitest/browser': 3.0.9(@types/node@22.13.10)(typescript@5.8.2)(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))(vitest@3.0.9)
       happy-dom: 17.4.4
     transitivePeerDependencies:
       - jiti
@@ -9542,7 +9914,8 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webidl-conversions@7.0.0: {}
+  webidl-conversions@7.0.0:
+    optional: true
 
   webpack-bundle-analyzer@4.6.1:
     dependencies:
@@ -9614,7 +9987,8 @@ snapshots:
 
   websocket-extensions@0.1.4: {}
 
-  whatwg-mimetype@3.0.0: {}
+  whatwg-mimetype@3.0.0:
+    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -9639,6 +10013,12 @@ snapshots:
   widest-line@5.0.0:
     dependencies:
       string-width: 7.2.0
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -9709,6 +10089,8 @@ snapshots:
       lib0: 0.2.99
 
   yocto-queue@1.2.0: {}
+
+  yoctocolors-cjs@2.1.2: {}
 
   zimmerframe@1.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: vje3sde4bbffdedre6hy3xjgai
     path: patches/@jupyter-widgets__base.patch
   '@jupyter-widgets/base-manager':
-    hash: z674c2pxqqojqpcabxwma3x3zu
+    hash: 7ecaeqgn7td3oasivzrewtjkwi
     path: patches/@jupyter-widgets__base-manager.patch
 
 importers:
@@ -143,7 +143,7 @@ importers:
         version: 6.0.10(patch_hash=vje3sde4bbffdedre6hy3xjgai)(react@19.0.0)
       '@jupyter-widgets/base-manager':
         specifier: ^1.0.11
-        version: 1.0.11(patch_hash=z674c2pxqqojqpcabxwma3x3zu)(react@19.0.0)
+        version: 1.0.11(patch_hash=7ecaeqgn7td3oasivzrewtjkwi)(react@19.0.0)
 
   packages/create-anywidget:
     dependencies:
@@ -5738,7 +5738,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@jupyter-widgets/base-manager@1.0.11(patch_hash=z674c2pxqqojqpcabxwma3x3zu)(react@19.0.0)':
+  '@jupyter-widgets/base-manager@1.0.11(patch_hash=7ecaeqgn7td3oasivzrewtjkwi)(react@19.0.0)':
     dependencies:
       '@jupyter-widgets/base': 6.0.10(patch_hash=vje3sde4bbffdedre6hy3xjgai)(react@19.0.0)
       '@jupyterlab/services': 7.3.5(react@19.0.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,14 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@jupyter-widgets/base':
+    hash: vje3sde4bbffdedre6hy3xjgai
+    path: patches/@jupyter-widgets__base.patch
+  '@jupyter-widgets/base-manager':
+    hash: z674c2pxqqojqpcabxwma3x3zu
+    path: patches/@jupyter-widgets__base-manager.patch
+
 importers:
 
   .:
@@ -27,8 +35,8 @@ importers:
         specifier: ^0.25.1
         version: 0.25.1
       happy-dom:
-        specifier: ^17.4.3
-        version: 17.4.3
+        specifier: ^17.4.4
+        version: 17.4.4
       publint:
         specifier: ^0.3.9
         version: 0.3.9
@@ -36,8 +44,8 @@ importers:
         specifier: ^5.8.2
         version: 5.8.2
       vitest:
-        specifier: ^3.0.8
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(happy-dom@17.4.3)(jiti@1.21.7)(yaml@2.7.0)
+        specifier: ^3.0.9
+        version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.10)(happy-dom@17.4.4)(jiti@1.21.7)(yaml@2.7.0)
 
   docs:
     dependencies:
@@ -132,10 +140,10 @@ importers:
     devDependencies:
       '@jupyter-widgets/base':
         specifier: ^6
-        version: 6.0.10(react@19.0.0)
+        version: 6.0.10(patch_hash=vje3sde4bbffdedre6hy3xjgai)(react@19.0.0)
       '@jupyter-widgets/base-manager':
         specifier: ^1.0.11
-        version: 1.0.11(react@19.0.0)
+        version: 1.0.11(patch_hash=z674c2pxqqojqpcabxwma3x3zu)(react@19.0.0)
 
   packages/create-anywidget:
     dependencies:
@@ -1654,11 +1662,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
-  '@vitest/expect@3.0.8':
-    resolution: {integrity: sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==}
+  '@vitest/expect@3.0.9':
+    resolution: {integrity: sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==}
 
-  '@vitest/mocker@3.0.8':
-    resolution: {integrity: sha512-n3LjS7fcW1BCoF+zWZxG7/5XvuYH+lsFg+BDwwAz0arIwHQJFUEsKBQ0BLU49fCxuM/2HSeBPHQD8WjgrxMfow==}
+  '@vitest/mocker@3.0.9':
+    resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -1668,20 +1676,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.0.8':
-    resolution: {integrity: sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==}
+  '@vitest/pretty-format@3.0.9':
+    resolution: {integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==}
 
-  '@vitest/runner@3.0.8':
-    resolution: {integrity: sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==}
+  '@vitest/runner@3.0.9':
+    resolution: {integrity: sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==}
 
-  '@vitest/snapshot@3.0.8':
-    resolution: {integrity: sha512-x8IlMGSEMugakInj44nUrLSILh/zy1f2/BgH0UeHpNyOocG18M9CWVIFBaXPt8TrqVZWmcPjwfG/ht5tnpba8A==}
+  '@vitest/snapshot@3.0.9':
+    resolution: {integrity: sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==}
 
-  '@vitest/spy@3.0.8':
-    resolution: {integrity: sha512-MR+PzJa+22vFKYb934CejhR4BeRpMSoxkvNoDit68GQxRLSf11aT6CTj3XaqUU9rxgWJFnqicN/wxw6yBRkI1Q==}
+  '@vitest/spy@3.0.9':
+    resolution: {integrity: sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==}
 
-  '@vitest/utils@3.0.8':
-    resolution: {integrity: sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==}
+  '@vitest/utils@3.0.9':
+    resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
 
   '@volar/kit@2.4.12':
     resolution: {integrity: sha512-f9JE8oy9C2rBcCWxUYKUF23hOXz4mwgVXFjk7nHhxzplaoVjEOsKpBm8NI2nBH7Cwu8DRxDwBsbIxMl/8wlLxw==}
@@ -2522,8 +2530,8 @@ packages:
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
-  happy-dom@17.4.3:
-    resolution: {integrity: sha512-8mDGIKxi2hAg0DkEYjBHPi5QykWiqdNNQQWrwLXLfro1eAZk8+lSnzbUrnU25bamG9PjEQGoFrA32ezQNJQdww==}
+  happy-dom@17.4.4:
+    resolution: {integrity: sha512-/Pb0ctk3HTZ5xEL3BZ0hK1AqDSAUuRQitOmROPHhfUYEWpmTImwfD8vFDGADmMAX0JYgbcgxWoLFKtsWhcpuVA==}
     engines: {node: '>=18.0.0'}
 
   has-flag@4.0.0:
@@ -4166,8 +4174,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@3.0.8:
-    resolution: {integrity: sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==}
+  vite-node@3.0.9:
+    resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -4250,16 +4258,16 @@ packages:
       vite:
         optional: true
 
-  vitest@3.0.8:
-    resolution: {integrity: sha512-dfqAsNqRGUc8hB9OVR2P0w8PZPEckti2+5rdZip0WIz9WW0MnImJ8XiR61QhqLa92EQzKP2uPkzenKOAHyEIbA==}
+  vitest@3.0.9:
+    resolution: {integrity: sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.0.8
-      '@vitest/ui': 3.0.8
+      '@vitest/browser': 3.0.9
+      '@vitest/ui': 3.0.9
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -5507,9 +5515,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@jupyter-widgets/base-manager@1.0.11(react@19.0.0)':
+  '@jupyter-widgets/base-manager@1.0.11(patch_hash=z674c2pxqqojqpcabxwma3x3zu)(react@19.0.0)':
     dependencies:
-      '@jupyter-widgets/base': 6.0.10(react@19.0.0)
+      '@jupyter-widgets/base': 6.0.10(patch_hash=vje3sde4bbffdedre6hy3xjgai)(react@19.0.0)
       '@jupyterlab/services': 7.3.5(react@19.0.0)
       '@lumino/coreutils': 2.2.0
       base64-js: 1.5.1
@@ -5519,7 +5527,7 @@ snapshots:
       - react
       - utf-8-validate
 
-  '@jupyter-widgets/base@6.0.10(react@19.0.0)':
+  '@jupyter-widgets/base@6.0.10(patch_hash=vje3sde4bbffdedre6hy3xjgai)(react@19.0.0)':
     dependencies:
       '@jupyterlab/services': 7.3.5(react@19.0.0)
       '@lumino/coreutils': 2.2.0
@@ -6239,43 +6247,43 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.0.8':
+  '@vitest/expect@3.0.9':
     dependencies:
-      '@vitest/spy': 3.0.8
-      '@vitest/utils': 3.0.8
+      '@vitest/spy': 3.0.9
+      '@vitest/utils': 3.0.9
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.8(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.9(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@vitest/spy': 3.0.8
+      '@vitest/spy': 3.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0)
 
-  '@vitest/pretty-format@3.0.8':
+  '@vitest/pretty-format@3.0.9':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.0.8':
+  '@vitest/runner@3.0.9':
     dependencies:
-      '@vitest/utils': 3.0.8
+      '@vitest/utils': 3.0.9
       pathe: 2.0.3
 
-  '@vitest/snapshot@3.0.8':
+  '@vitest/snapshot@3.0.9':
     dependencies:
-      '@vitest/pretty-format': 3.0.8
+      '@vitest/pretty-format': 3.0.9
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@3.0.8':
+  '@vitest/spy@3.0.9':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@3.0.8':
+  '@vitest/utils@3.0.9':
     dependencies:
-      '@vitest/pretty-format': 3.0.8
+      '@vitest/pretty-format': 3.0.9
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -7255,7 +7263,7 @@ snapshots:
 
   handle-thing@2.0.1: {}
 
-  happy-dom@17.4.3:
+  happy-dom@17.4.4:
     dependencies:
       webidl-conversions: 7.0.0
       whatwg-mimetype: 3.0.0
@@ -9328,7 +9336,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.0.8(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0):
+  vite-node@3.0.9(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
@@ -9373,15 +9381,15 @@ snapshots:
     optionalDependencies:
       vite: 5.4.14(@types/node@18.19.80)
 
-  vitest@3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(happy-dom@17.4.3)(jiti@1.21.7)(yaml@2.7.0):
+  vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.13.10)(happy-dom@17.4.4)(jiti@1.21.7)(yaml@2.7.0):
     dependencies:
-      '@vitest/expect': 3.0.8
-      '@vitest/mocker': 3.0.8(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))
-      '@vitest/pretty-format': 3.0.8
-      '@vitest/runner': 3.0.8
-      '@vitest/snapshot': 3.0.8
-      '@vitest/spy': 3.0.8
-      '@vitest/utils': 3.0.8
+      '@vitest/expect': 3.0.9
+      '@vitest/mocker': 3.0.9(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))
+      '@vitest/pretty-format': 3.0.9
+      '@vitest/runner': 3.0.9
+      '@vitest/snapshot': 3.0.9
+      '@vitest/spy': 3.0.9
+      '@vitest/utils': 3.0.9
       chai: 5.2.0
       debug: 4.4.0
       expect-type: 1.2.0
@@ -9393,12 +9401,12 @@ snapshots:
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
       vite: 6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0)
-      vite-node: 3.0.8(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0)
+      vite-node: 3.0.9(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.13.10
-      happy-dom: 17.4.3
+      happy-dom: 17.4.4
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,10 +33,13 @@ importers:
         version: 1.2.0
       '@vitest/browser':
         specifier: ^3.0.9
-        version: 3.0.9(@types/node@22.13.10)(typescript@5.8.2)(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))(vitest@3.0.9)
+        version: 3.0.9(@types/node@22.13.10)(playwright@1.51.1)(typescript@5.8.2)(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))(vitest@3.0.9)
       esbuild:
         specifier: ^0.25.1
         version: 0.25.1
+      playwright:
+        specifier: ^1.51.1
+        version: 1.51.1
       publint:
         specifier: ^0.3.9
         version: 0.3.9
@@ -2562,6 +2565,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3551,6 +3559,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.51.1:
+    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.51.1:
+    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -6509,7 +6527,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.0.9(@types/node@22.13.10)(typescript@5.8.2)(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))(vitest@3.0.9)':
+  '@vitest/browser@3.0.9(@types/node@22.13.10)(playwright@1.51.1)(typescript@5.8.2)(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))(vitest@3.0.9)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
@@ -6521,6 +6539,8 @@ snapshots:
       tinyrainbow: 2.0.0
       vitest: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.9)(happy-dom@17.4.4)(jiti@1.21.7)(msw@2.7.3(@types/node@22.13.10)(typescript@5.8.2))(yaml@2.7.0)
       ws: 8.18.1
+    optionalDependencies:
+      playwright: 1.51.1
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -7480,6 +7500,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -8736,6 +8759,14 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
+  playwright-core@1.51.1: {}
+
+  playwright@1.51.1:
+    dependencies:
+      playwright-core: 1.51.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss-import@15.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
@@ -9777,7 +9808,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.13.10
-      '@vitest/browser': 3.0.9(@types/node@22.13.10)(typescript@5.8.2)(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))(vitest@3.0.9)
+      '@vitest/browser': 3.0.9(@types/node@22.13.10)(playwright@1.51.1)(typescript@5.8.2)(vite@6.2.1(@types/node@22.13.10)(jiti@1.21.7)(yaml@2.7.0))(vitest@3.0.9)
       happy-dom: 17.4.4
     transitivePeerDependencies:
       - jiti

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
 		"verbatimModuleSyntax": true,
 		"skipLibCheck": true,
 		"allowJs": true,
-		"checkJs": true
+		"checkJs": true,
+		"types": ["@vitest/browser/matchers"]
 	},
 	"files": [],
 	"references": [

--- a/vitest.workspace.js
+++ b/vitest.workspace.js
@@ -3,9 +3,12 @@ import { defineWorkspace } from "vitest/config";
 export default defineWorkspace([
 	{
 		test: {
-			include: ["packages/create-anywidget/**/*.test.{js,ts}"],
+			exclude: ["**/node_modules/**", "**/dist/**", "packages/anywidget/**"],
 			name: "unit",
 			environment: "node",
+			typecheck: {
+				enabled: true,
+			},
 		},
 	},
 	{
@@ -13,6 +16,8 @@ export default defineWorkspace([
 			include: ["packages/anywidget/**/*.test.{js,ts}"],
 			name: "browser",
 			browser: {
+				provider: "playwright",
+				headless: true,
 				enabled: true,
 				instances: [{ browser: "chromium" }],
 			},

--- a/vitest.workspace.js
+++ b/vitest.workspace.js
@@ -1,0 +1,21 @@
+import { defineWorkspace } from "vitest/config";
+
+export default defineWorkspace([
+	{
+		test: {
+			include: ["packages/create-anywidget/**/*.test.{js,ts}"],
+			name: "unit",
+			environment: "node",
+		},
+	},
+	{
+		test: {
+			include: ["packages/anywidget/**/*.test.{js,ts}"],
+			name: "browser",
+			browser: {
+				enabled: true,
+				instances: [{ browser: "chromium" }],
+			},
+		},
+	},
+]);


### PR DESCRIPTION
Uses the Web `AbortController` API to manage subscribers to the Jupyter
Widgets model. This removes lots of the complexity around managing and
removing subscribers by allowing `AnyModel` and `AnyView` to "abort"
their on subscriptions when removed by ipywidgets.
