### PR TITLE
fix: zebra striping in dark mode

### DIFF
--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -271,7 +271,7 @@ table {
 
 /* Zebra striping */
 tr:nth-of-type(odd) {
-	background: var(--theme-bg-hover);
+	background: var(--theme-bg-offset);
 }
 th {
 	background: var(--color-black);


### PR DESCRIPTION
Fix #829 

## Before

<img width="603" alt="Screenshot 2025-03-19 at 12 16 07 PM" src="https://github.com/user-attachments/assets/5751edcb-5f23-45c5-9a93-cf03ace930b6" />

<img width="593" alt="Screenshot 2025-03-19 at 12 15 15 PM" src="https://github.com/user-attachments/assets/26fcaf11-cf4a-4097-95ac-2761eba98010" />



## After

<img width="596" alt="Screenshot 2025-03-19 at 12 16 15 PM" src="https://github.com/user-attachments/assets/07dd93af-ee56-4493-b1c4-ae4f5cb6ef9b" />

<img width="594" alt="Screenshot 2025-03-19 at 12 15 07 PM" src="https://github.com/user-attachments/assets/4c488c43-4a89-4ac9-beee-b8a69193aa7d" />
