### PR TITLE
Fix descriptor API to send initial state for consistent behavior

### DIFF
--- a/.changeset/bumpy-loops-battle.md
+++ b/.changeset/bumpy-loops-battle.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+**experimental** Fix descriptor API to send initial state on comm creation


### PR DESCRIPTION
Resolves a bug in the experimental descriptor API by ensuring the initial widget state is sent during comm setup.
