### PR TITLE
feat(react): Use `React.useSyncExternalStore` and type `useModel` hook

### DIFF
--- a/.changeset/blue-feet-fall.md
+++ b/.changeset/blue-feet-fall.md
@@ -1,0 +1,5 @@
+---
+"@anywidget/react": patch
+---
+
+Add generic type parameter to `useModel` hook

--- a/.changeset/sad-yaks-kiss.md
+++ b/.changeset/sad-yaks-kiss.md
@@ -1,0 +1,16 @@
+---
+"@anywidget/react": minor
+---
+
+Use `React.useSyncExternalStore` for `useModelState` hook implementation
+
+The
+[`React.useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore)
+hook was introduced in React 18 and is designed for external sources of truth,
+like the anywidget `model`. It ensures a shared source within the component
+tree, and consistent behavior during concurrent rendering, avoiding subtle bugs
+present in `useEffect`-based patterns.
+
+This is marked as a **breaking change** to signal the internal shift in behavior,
+though in practice it should be considered an improvement. Most users should not
+notice any difference, aside from more consistent updates.

--- a/.changeset/slow-emus-kneel.md
+++ b/.changeset/slow-emus-kneel.md
@@ -1,0 +1,7 @@
+---
+"@anywidget/react": minor
+---
+
+Mirror `React.useState` API in `useModelState` hook
+
+Aligns the `useModelState` hook more closely with the `React.useState` API by allowing a callback function in the state setter.

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -2,22 +2,28 @@ import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 
 /**
+ * @template {Record<string, any>} T
  * @typedef RenderContext
- * @property {import("@anywidget/types").AnyModel} model
+ * @property {import("@anywidget/types").AnyModel<T>} model
  * @property {import("@anywidget/types").Experimental} experimental
  */
 
-/** @type {React.Context<RenderContext>} */
+/** @type {React.Context<RenderContext<any>>} */
 let RenderContext = React.createContext(/** @type {any} */ (null));
 
-/** @returns {RenderContext} */
+/**
+ * @returns {RenderContext<any>}
+ */
 function useRenderContext() {
 	let ctx = React.useContext(RenderContext);
 	if (!ctx) throw new Error("RenderContext not found");
 	return ctx;
 }
 
-/** @returns {import("@anywidget/types").AnyModel} */
+/**
+ * @template {Record<string, any>} T
+ * @returns {import("@anywidget/types").AnyModel<T>}
+ */
 export function useModel() {
 	let ctx = useRenderContext();
 	return ctx.model;
@@ -30,26 +36,53 @@ export function useExperimental() {
 }
 
 /**
- * @template T
+ * A React Hook to use model-backed state in a component.
  *
- * @param {string} key
- * @returns {[T, (value: T) => void]}
+ * Mirrors the API of `React.useState`, but synchronizes state with
+ * the underlying model provded by an anywidget host.
+ *
+ * @example
+ * ```ts
+ * import * as React from "react";
+ * import { useModelState } from "@anywidget/react";
+ *
+ * function Counter() {
+ *   let [value, setValue] = useModelState<number>("value");
+ *
+ *   return (
+ *     <button onClick={() => setValue((v) => v + 1)}>
+ *       Count: {value}
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @template S
+ * @param {string} key - The name of the model field to use
+ * @returns {[S, React.Dispatch<React.SetStateAction<S>>]}
  */
 export function useModelState(key) {
 	let model = useModel();
-	let [value, setValue] = React.useState(model.get(key));
-	React.useEffect(() => {
-		let callback = () => setValue(model.get(key));
-		model.on(`change:${key}`, callback);
-		return () => model.off(`change:${key}`, callback);
-	}, [model, key]);
-	return [
-		value,
+	let value = React.useSyncExternalStore(
+		(update) => {
+			model.on(`change:${key}`, update);
+			return () => model.off(`change:${key}`, update);
+		},
+		() => model.get(key),
+	);
+	/** @type {React.Dispatch<React.SetStateAction<S>>} */
+	let setValue = React.useCallback(
 		(value) => {
-			model.set(key, value);
+			model.set(
+				key,
+				// @ts-expect-error - TS cannot correctly narrow type
+				typeof value === "function" ? value(model.get(key)) : value,
+			);
 			model.save_changes();
 		},
-	];
+		[model, key],
+	);
+	return [value, setValue];
 }
 
 /**


### PR DESCRIPTION
Changes `useModelState` to use [`React.useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore) instead of `useState` + `useEffect`. The hook was introduced in React 18 and is designed for our exact use case (an external source of truth). It ensures a shared source within the component tree, and consistent behavior during concurrent rendering, avoiding subtle bugs present in `useEffect`-based patterns.

The setter function also now mirrors `useState` behavior more precisely, supporting both direct values and functional updates. Also adds generic type param for `useModel` hook.