### PR TITLE
feat: Vue AFM bridge

### DIFF
--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @anywidget/vue
+
+## 0.0.1
+
+### Patch Changes
+
+- fix: specify "types" field in package.json ([#198](https://github.com/manzt/anywidget/pull/198))

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,7 +1,1 @@
 # @anywidget/vue
-
-## 0.0.1
-
-### Patch Changes
-
-- fix: specify "types" field in package.json ([#198](https://github.com/manzt/anywidget/pull/198))

--- a/packages/vue/LICENSE
+++ b/packages/vue/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-2023 Trevor Manz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,63 @@
+# @anywidget/vue
+
+> Vue utilities for [**anywidget**](https://anywidget.dev)
+
+## Installation
+
+```sh
+npm install @anywidget/vue
+```
+
+## Usage
+
+```javascript
+// src/index.js
+import { createRender } from "@anywidget/vue";
+import CounterWidget from "./CounterWidget.vue";
+
+const render = createRender(CounterWidget);
+
+export default { render };
+```
+
+```vue
+<!-- src/CounterWidget.vue -->
+<script setup>
+import { useModelState } from "@anywidget/vue";
+
+const value = useModelState("value");
+</script>
+
+<template>
+<button :onClick="() => value++">count is {{value}}</button>
+</template>
+```
+
+## Bundling
+
+```javascript
+// vite.config.js
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// https://vite.dev/config/
+export default defineConfig({
+	plugins: [vue()],
+	build: {
+		lib: {
+			entry: resolve(__dirname, 'src/index.js'),
+			// the proper extensions will be added
+			fileName: 'counter-widget',
+			formats: ['es'],
+		},
+	},
+});
+```
+
+## License
+
+MIT

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -31,32 +31,65 @@ const value = useModelState("value");
 <template>
 <button :onClick="() => value++">count is {{value}}</button>
 </template>
+
+<style scoped>
+</style>
 ```
 
-## Bundling
+## Bundlers
+
+You'll need to compile the above source files into a single ESM entrypoint for
+**anywidget** with a bundler.
+
+### Vite
+
+We currently recommend using [Vite](https://vite.dev/) in [library mode](https://vite.dev/guide/build.html#library-mode).
+
+```sh
+pnpm add -D @types/node @vitejs/plugin-vue vite
+```
 
 ```javascript
 // vite.config.js
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vite';
-import vue from '@vitejs/plugin-vue';
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig({
-	plugins: [vue()],
+	plugins: [
+		vue(),
+	],
 	build: {
 		lib: {
-			entry: resolve(__dirname, 'src/index.js'),
+			entry: resolve(__dirname, "js/CounterWidget.ts"),
 			// the proper extensions will be added
-			fileName: 'counter-widget',
-			formats: ['es'],
+			fileName: "counter-widget",
+			formats: ["es"],
 		},
+		// minify: false, // Uncomment to make it easier to debug errors.
+	},
+	define: {
+		// DOCS: https://vite.dev/guide/build.html#css-support
+		// > In library mode, all import.meta.env.* usage are statically replaced when building for production.
+		// > However, process.env.* usage are not, so that consumers of your library can dynamically change it.
+		//
+		// The consumer of the widget is a webview, which does not have a top level process object.
+		// So we need to replace it with a static value.
+		'process.env.NODE_ENV': '"production"',
 	},
 });
 ```
+
+```sh
+vite build
+```
+
+You can read more about using Vite with **anywidget** in
+[our documentation](https://anywidget.dev/en/bundling/#vite).
 
 ## License
 

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -1,0 +1,151 @@
+import {
+	createApp,
+	customRef,
+	defineComponent,
+	h,
+	inject,
+	onMounted,
+	onUnmounted,
+	provide,
+	toValue,
+	unref,
+} from "vue";
+
+
+/**
+ * @template {Record<string, any>} T
+ * @typedef RenderContext
+ * @property {import("@anywidget/types").AnyModel<T>} model
+ * @property {import("@anywidget/types").Experimental} experimental
+ */
+
+/**
+ * @type {import("vue").InjectionKey<RenderContext<any>>}
+ */
+const RENDER_CONTEXT_KEY = Symbol("anywidget.RenderContext");
+
+/**
+ * @returns {RenderContext<any>}
+ */
+function useRenderContext() {
+	let ctx = inject(RENDER_CONTEXT_KEY);
+	if (!ctx) throw new Error("anywidget.RenderContext is not provided.");
+	return ctx;
+}
+
+/**
+ * @template {Record<string, any>} T
+ * @returns {import("@anywidget/types").AnyModel<T>}
+ */
+export function useModel() {
+	let ctx = useRenderContext();
+	return ctx.model;
+}
+
+/** @returns {import("@anywidget/types").Experimental} */
+export function useExperimental() {
+	let ctx = useRenderContext();
+	return ctx.experimental;
+}
+
+/**
+ * A Vue Composable to use model-backed state in a component.
+ *
+ * Returns a ShallowRef that synchronizes its value with
+ * the underlying model provided by an anywidget host.
+ *
+ * @example
+ * ```ts
+ * import { useModelState } from "@anywidget/vue";
+ *
+ * function Counter() {
+ *   const value = useModelState<number>("value");
+ *
+ *   return (
+ *     <button onClick={() => value++}>
+ *       Count: {value}
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @template S
+ * @param {import("vue").MaybeRef<string>} key - The name of the model field to use
+ * @returns {import("vue").ShallowRef<S>}
+ */
+export function useModelState(key) {
+	const model = useModel();
+
+	/**
+	 * @type {VoidFunction}
+	 */
+	let trigger;
+
+	/**
+	 * @type {import("vue").Ref<S>}
+	 */
+	const value = customRef((_track, _trigger) => {
+		trigger = _trigger;
+		return {
+			get() {
+				_track();
+				return model.get(unref(key));
+			},
+			set(newValue) {
+				model.set(
+					unref(key),
+					toValue(newValue),
+				);
+				model.save_changes();
+			},
+		}
+	})
+
+	const update = () => {
+		value.value = model.get(unref(key));
+		trigger();
+	};
+
+	onMounted(() => {
+		model.on(`change:${key}`, update);
+	});
+
+	onUnmounted(() => {
+		model.off(`change:${key}`, update);
+	});
+
+	return value;
+}
+
+/**
+ * @type {import("vue").DefineSetupFnComponent<RenderContext<any>>}
+ */
+const WidgetWrapper = defineComponent(
+  ({ model, experimental }, ctx) => {
+    provide(RENDER_CONTEXT_KEY, { model, experimental });
+    return () => ctx.slots?.default?.();
+  },
+  {
+	props: ["model", "experimental"],
+    name: 'WidgetWrapper'
+  }
+);
+
+/**
+ * @param {import("vue").Component} Widget
+ * @returns {import("@anywidget/types").Render}
+ */
+export function createRender(Widget) {
+	return ({ el, model, experimental }) => {
+		const app = createApp(
+			h(
+				WidgetWrapper,
+				{ model, experimental },
+				h(Widget),
+			),
+		)
+		app.mount(el);
+
+		return () => app.unmount();
+	};
+}

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -11,7 +11,6 @@ import {
 	unref,
 } from "vue";
 
-
 /**
  * @template {Record<string, any>} T
  * @typedef RenderContext
@@ -92,14 +91,11 @@ export function useModelState(key) {
 				return model.get(unref(key));
 			},
 			set(newValue) {
-				model.set(
-					unref(key),
-					toValue(newValue),
-				);
+				model.set(unref(key), toValue(newValue));
 				model.save_changes();
 			},
-		}
-	})
+		};
+	});
 
 	const update = () => {
 		value.value = model.get(unref(key));
@@ -121,14 +117,14 @@ export function useModelState(key) {
  * @type {import("vue").DefineSetupFnComponent<RenderContext<any>>}
  */
 const WidgetWrapper = defineComponent(
-  ({ model, experimental }, ctx) => {
-    provide(RENDER_CONTEXT_KEY, { model, experimental });
-    return () => ctx.slots?.default?.();
-  },
-  {
-	props: ["model", "experimental"],
-    name: 'WidgetWrapper'
-  }
+	({ model, experimental }, ctx) => {
+		provide(RENDER_CONTEXT_KEY, { model, experimental });
+		return () => ctx.slots?.default?.();
+	},
+	{
+		props: ["model", "experimental"],
+		name: "WidgetWrapper",
+	},
 );
 
 /**
@@ -137,13 +133,7 @@ const WidgetWrapper = defineComponent(
  */
 export function createRender(Widget) {
 	return ({ el, model, experimental }) => {
-		const app = createApp(
-			h(
-				WidgetWrapper,
-				{ model, experimental },
-				h(Widget),
-			),
-		)
+		const app = createApp(h(WidgetWrapper, { model, experimental }, h(Widget)));
 		app.mount(el);
 
 		return () => app.unmount();

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@anywidget/vue",
+	"type": "module",
+	"version": "0.0.0",
+	"description": "Vue utilities for anywidget",
+	"main": "index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./index.js"
+		}
+	},
+	"peerDependencies": {
+		"vue": "^3.5.13"
+	},
+	"devDependencies": {
+		"vue": "^3.5.13"
+	},
+	"dependencies": {
+		"@anywidget/types": "workspace:^"
+	}
+}

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["*.js"],
+	"compilerOptions": {
+		"outDir": "dist",
+		"emitDeclarationOnly": true
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,16 @@ importers:
         specifier: ^6.2.6
         version: 6.3.2(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1)
 
+  packages/vue:
+    dependencies:
+      '@anywidget/types':
+        specifier: workspace:^
+        version: link:../types
+    devDependencies:
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.13(typescript@5.8.3)
+
 packages:
 
   '@algolia/autocomplete-core@1.17.9':
@@ -1732,6 +1742,35 @@ packages:
 
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
+
+  '@vue/compiler-core@3.5.13':
+    resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
+
+  '@vue/compiler-dom@3.5.13':
+    resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
+
+  '@vue/compiler-sfc@3.5.13':
+    resolution: {integrity: sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==}
+
+  '@vue/compiler-ssr@3.5.13':
+    resolution: {integrity: sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==}
+
+  '@vue/reactivity@3.5.13':
+    resolution: {integrity: sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==}
+
+  '@vue/runtime-core@3.5.13':
+    resolution: {integrity: sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==}
+
+  '@vue/runtime-dom@3.5.13':
+    resolution: {integrity: sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==}
+
+  '@vue/server-renderer@3.5.13':
+    resolution: {integrity: sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==}
+    peerDependencies:
+      vue: 3.5.13
+
+  '@vue/shared@3.5.13':
+    resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -4422,6 +4461,14 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue@3.5.13:
+    resolution: {integrity: sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   wbuf@1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
 
@@ -6377,6 +6424,60 @@ snapshots:
       vscode-uri: 3.1.0
 
   '@vscode/l10n@0.0.18': {}
+
+  '@vue/compiler-core@3.5.13':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@vue/shared': 3.5.13
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.13':
+    dependencies:
+      '@vue/compiler-core': 3.5.13
+      '@vue/shared': 3.5.13
+
+  '@vue/compiler-sfc@3.5.13':
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@vue/compiler-core': 3.5.13
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-ssr': 3.5.13
+      '@vue/shared': 3.5.13
+      estree-walker: 2.0.2
+      magic-string: 0.30.17
+      postcss: 8.5.3
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.13':
+    dependencies:
+      '@vue/compiler-dom': 3.5.13
+      '@vue/shared': 3.5.13
+
+  '@vue/reactivity@3.5.13':
+    dependencies:
+      '@vue/shared': 3.5.13
+
+  '@vue/runtime-core@3.5.13':
+    dependencies:
+      '@vue/reactivity': 3.5.13
+      '@vue/shared': 3.5.13
+
+  '@vue/runtime-dom@3.5.13':
+    dependencies:
+      '@vue/reactivity': 3.5.13
+      '@vue/runtime-core': 3.5.13
+      '@vue/shared': 3.5.13
+      csstype: 3.1.3
+
+  '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@5.8.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.13
+      '@vue/shared': 3.5.13
+      vue: 3.5.13(typescript@5.8.3)
+
+  '@vue/shared@3.5.13': {}
 
   accepts@1.3.8:
     dependencies:
@@ -9578,6 +9679,16 @@ snapshots:
   vscode-textmate@8.0.0: {}
 
   vscode-uri@3.1.0: {}
+
+  vue@3.5.13(typescript@5.8.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-sfc': 3.5.13
+      '@vue/runtime-dom': 3.5.13
+      '@vue/server-renderer': 3.5.13(vue@3.5.13(typescript@5.8.3))
+      '@vue/shared': 3.5.13
+    optionalDependencies:
+      typescript: 5.8.3
 
   wbuf@1.7.3:
     dependencies:


### PR DESCRIPTION
Hey, awesome project! 🎉

I wanted to create some custom widgets using Vue, and since you already have packages for React and Svelte, I decided to contribute the Vue binding code.

The API of the Vue binding is very similar to the @anywidget/react package. The major difference is that instead of returning a getter-setter pair from `useModelState`, we return a `ShallowRef` which can be mutated directly (eg. `value++`). This is more idiomatic to Vue's reactivity system.

## Current Status

I haven't figured out how to get HMR to work, so for now, you’ll need to restart the kernel for updated JS/CSS files to be picked up. If this can be addressed in a patch release, great! Otherwise, I’ll revisit it in a few days to troubleshoot further.

## Demo

You can check out a demo of this package on the branch [aryan02420:demo/vue-bridge](https://github.com/aryan02420/anywidget/tree/demo/vue-bridge/packages/vue-demo).

![demo of the custom widget rendered using vue](https://github.com/user-attachments/assets/69a25497-a197-4eb7-ab0e-2ffdc55e3d9c)
