### PR TITLE
Auto sync deps before running `pnpm` commands

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+verifyDepsBeforeRun: install
 packages:
   - "packages/*"
   - "docs/**"


### PR DESCRIPTION
This setting allows the checking of the state of dependencies before
running scripts. The check runs on `pnpm run` and `pnpm exec` commands,
automatically running install if `node_modules` is not up to date.
