### PR TITLE
Exclude `docs` and `paper` from sdist/wheel

### DIFF
--- a/.changeset/calm-falcons-brush.md
+++ b/.changeset/calm-falcons-brush.md
@@ -1,0 +1,5 @@
+---
+"anywidget": patch
+---
+
+Exclude `docs/` and `paper/` from sdist/wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ exclude_lines = [
 ]
 
 [tool.hatch.build]
-exclude = [".github"]
+exclude = [".github", "docs", "paper"]
 artifacts = [
   "anywidget/nbextension/index.*",
   "anywidget/labextension/*.tgz",


### PR DESCRIPTION
Fixes #901