### PR TITLE
Use rsbuild inline sourcemaps for JupyterLab extension

### DIFF
--- a/.changeset/khaki-houses-poke.md
+++ b/.changeset/khaki-houses-poke.md
@@ -1,0 +1,14 @@
+---
+"anywidget": patch
+---
+
+Use rsbuild inline sourcemaps for JupyterLab extension
+
+JupyterLab was refusing to load external source map files because they were
+being served with the wrong MIME type ('application/octet-stream' instead of
+the expected source map MIME type). This caused the extension to fail loading
+in version 0.9.20.
+
+Switching to inline source maps embeds the source map directly in the
+JavaScript bundle, avoiding the MIME type issue while still providing source
+map support for debugging.

--- a/packages/anywidget/scripts/jlab.config.cjs
+++ b/packages/anywidget/scripts/jlab.config.cjs
@@ -12,7 +12,7 @@ fs.rmSync(out, { recursive: true, force: true });
 module.exports = {
 	mode: "production",
 	optimization: { minimize: false },
-	devtool: "source-map",
+	devtool: "inline-source-map",
 	entry: path.resolve(root, "src/index.js"),
 	output: {
 		filename: "[name].[contenthash:8].js",


### PR DESCRIPTION
Fixes #908

JupyterLab was refusing to load external source map files because they were being served with the wrong MIME type ('application/octet-stream' instead of the expected source map MIME type). This caused the extension to fail loading in version 0.9.20.

Switching to inline source maps embeds the source map directly in the JavaScript bundle, avoiding the MIME type issue entirely while still providing source map support for debugging.