### PR TITLE
Fix release workflow to use vp instead of pnpm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm release
+          publish: vp run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { playwright } from "vite-plus/test/browser-playwright";
 export default defineConfig({
   fmt: {
     experimentalSortImports: {},
+    ignorePatterns: ["CHANGELOG.md"],
   },
   lint: {
     plugins: ["typescript", "import"],


### PR DESCRIPTION
The migration to the vite-plus (vp) toolchain in #965 set up `setup-vp` in the release workflow but left the changesets publish command pointing at `pnpm release`, which isn't on PATH in that environment. Switching to `vp run release` fixes the release since `vp` delegates to pnpm internally for script execution.