### PR TITLE
Fix orphaned ready promise on widget rebind

### DIFF
--- a/packages/anywidget/src/binding.ts
+++ b/packages/anywidget/src/binding.ts
@@ -40,8 +40,14 @@ export class WidgetBinding {
 
     if (this.#widgetDef && this.#widgetDef !== widgetDef) {
       this.#controller?.abort();
+      // Settle the old promise so any awaiter that captured `this.ready`
+      // (e.g. a parent's `host.getWidget` snapshot) unblocks instead of
+      // hanging until the host's 10s timeout. No-op if already resolved.
+      let prevResolvers = this.#resolvers;
       this.#resolvers = promiseWithResolvers();
       this.ready = this.#resolvers.promise;
+      prevResolvers.promise.catch(() => {});
+      prevResolvers.reject(new Error("[anywidget] widget bind aborted by re-bind"));
     }
 
     this.#widgetDef = widgetDef;


### PR DESCRIPTION
`WidgetBinding.bind` swapped `#resolvers` and ready on rebind without settling the prior promise.

A parent that captured the old promise via `host.getWidget` could hang until the host's 10s timeout fired and rejected with a misleading 'Timed out waiting for widget to initialize' error, even though the rebind succeeded. Reject the old resolvers (a no-op if already settled) so captured awaiters unblock immediately with a clear reason, and attach a noop catch to suppress unhandled-rejection warnings when no consumer was attached.