### PR TITLE
Patch ipywidgets to accept anywidgets in Box and Link

### DIFF
--- a/anywidget/__init__.py
+++ b/anywidget/__init__.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from ._patch_ipywidgets import patch_ipywidgets
 from ._protocols import AnywidgetProtocol as Widget
 from ._traits import WidgetTrait
 from ._version import __version__
 from .widget import AnyWidget
 
 __all__ = ["AnyWidget", "Widget", "WidgetTrait", "__version__"]
+
+patch_ipywidgets()
 
 
 def _jupyter_labextension_paths() -> list[dict]:

--- a/anywidget/_patch_ipywidgets.py
+++ b/anywidget/_patch_ipywidgets.py
@@ -1,0 +1,104 @@
+"""Make ipywidgets.Box and ipywidgets.Link accept anywidget objects.
+
+ipywidgets validates that ``Box.children`` and ``Link.{source,target}`` are
+``ipywidgets.Widget`` instances. Protocol-based anywidgets (those using
+``MimeBundleDescriptor`` rather than subclassing ``Widget``) get rejected.
+
+This module relaxes those validators to accept anything ``_try_get_model_id``
+recognizes, and wires up serializers that emit ``IPY_MODEL_<id>`` — the form
+ipywidgets' JS side expects when reconstructing Box children and Link
+endpoints.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import ipywidgets
+import traitlets
+from ipywidgets.widgets.trait_types import TypedTuple
+from ipywidgets.widgets.widget import _instances
+
+from ._descriptor import _try_get_model_id
+
+
+def _to_json(value: t.Any, _obj: t.Any) -> t.Any:
+    if isinstance(value, dict):
+        return {k: _to_json(v, _obj) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_json(v, _obj) for v in value]
+    model_id = _try_get_model_id(value)
+    return f"IPY_MODEL_{model_id}" if model_id is not None else value
+
+
+def _from_json(value: t.Any, _obj: t.Any) -> t.Any:
+    if isinstance(value, dict):
+        return {k: _from_json(v, _obj) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_from_json(v, _obj) for v in value]
+    if (
+        isinstance(value, str)
+        and value.startswith("IPY_MODEL_")
+        and value[len("IPY_MODEL_") :] in _instances
+    ):
+        return _instances[value[len("IPY_MODEL_") :]]
+    return value
+
+
+class _AnyWidgetTrait(traitlets.TraitType):
+    info_text = "an anywidget-compatible object"
+
+    def validate(self, obj: t.Any, value: t.Any) -> t.Any:
+        if _try_get_model_id(value) is not None:
+            return value
+        self.error(obj, value)
+        return None
+
+
+class _AnyWidgetTraitTuple(traitlets.Tuple):
+    info_text = "a (Widget, 'trait_name') pair"
+
+    def __init__(self) -> None:
+        super().__init__(_AnyWidgetTrait(), traitlets.Unicode())
+
+    def validate_elements(self, obj: t.Any, value: t.Any) -> t.Any:
+        value = super().validate_elements(obj, value)
+        widget, trait_name = value
+        # Only ipywidgets.Widget instances expose .traits(). Protocol
+        # widgets are trusted — their state surface isn't introspectable here.
+        if isinstance(widget, ipywidgets.Widget):
+            trait = widget.traits().get(trait_name)
+            label = f"{widget.__class__.__name__}.{trait_name}"
+            if trait is None:
+                raise TypeError(f"No such trait: {label}")
+            if not trait.metadata.get("sync"):
+                raise TypeError(f"{label} cannot be synced")
+        return value
+
+
+_PATCHED = False
+
+
+def patch_ipywidgets() -> None:
+    """Relax Box.children and {Directional,}Link.{source,target} to accept anywidgets."""
+    global _PATCHED  # noqa: PLW0603
+    if _PATCHED:
+        return
+
+    children = ipywidgets.Box.children
+    children.metadata["to_json"] = _to_json
+    children.metadata["from_json"] = _from_json
+    children.validate = TypedTuple(_AnyWidgetTrait()).validate
+
+    link_module = ipywidgets.widgets.widget_link
+    for endpoint in (
+        link_module.Link.source,
+        link_module.Link.target,
+        link_module.DirectionalLink.source,
+        link_module.DirectionalLink.target,
+    ):
+        endpoint.metadata["to_json"] = _to_json
+        endpoint.metadata["from_json"] = _from_json
+        endpoint.validate_elements = _AnyWidgetTraitTuple().validate_elements
+
+    _PATCHED = True

--- a/commit.md
+++ b/commit.md
@@ -1,0 +1,16 @@
+Patch ipywidgets to accept anywidgets in Box and Link
+
+`ipywidgets.Box.children` and `ipywidgets.{Directional,}Link.{source,target}`
+do strict `isinstance(x, ipywidgets.Widget)` checks, which rejects
+protocol-based anywidgets (those using `MimeBundleDescriptor` rather than
+subclassing `Widget`). Users routinely want `HBox([my_anywidget])` and
+`link((a, "x"), (b, "x"))` to just work; the new composition API in #974
+solves anywidget-to-anywidget composition but leaves the bridge to
+ipywidgets' built-in containers unsolved.
+
+Mutating someone else's library at import time is a hack, but ipywidgets
+is effectively frozen and "anywidgets are widgets" — the patch makes the
+world correct rather than deceiving it. Applied eagerly from `__init__`
+with a `_PATCHED` guard for idempotence. Only the high-traffic traits are
+covered; obscure widget-ref traits (Tab, controllers, etc.) are deferred
+until requested.

--- a/tests/test_patch_ipywidgets.py
+++ b/tests/test_patch_ipywidgets.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import ipywidgets
+import pytest
+import traitlets
+from anywidget._patch_ipywidgets import (
+    _AnyWidgetTrait,
+    _AnyWidgetTraitTuple,
+    _from_json,
+    _to_json,
+    patch_ipywidgets,
+)
+
+
+class FakeAnywidget(traitlets.HasTraits):
+    """Stand-in for any object _try_get_model_id recognizes.
+
+    Real protocol widgets work the same way (their MimeBundleDescriptor
+    exposes a model_id), but constructing them in tests requires a comm
+    fixture and weakref-cleanup gymnastics that aren't relevant here —
+    the patch only cares whether _try_get_model_id returns a string.
+
+    Inherits from HasTraits so traitlets.link's own validation (separate
+    from anywidget's patch) accepts it as an endpoint.
+    """
+
+    value = traitlets.Int(0).tag(sync=True)
+
+    def __init__(self, model_id: str = "abc") -> None:
+        super().__init__()
+        self.model_id = model_id
+
+
+def test_patch_is_applied_on_import() -> None:
+    # `import anywidget` runs patch_ipywidgets(); subsequent calls are no-ops.
+    from anywidget._patch_ipywidgets import _PATCHED
+
+    assert _PATCHED
+
+
+def test_patch_is_idempotent() -> None:
+    before = ipywidgets.Box.children.metadata["to_json"]
+    patch_ipywidgets()
+    patch_ipywidgets()
+    assert ipywidgets.Box.children.metadata["to_json"] is before
+
+
+def test_to_json_emits_ipy_model_prefix() -> None:
+    assert _to_json(FakeAnywidget("abc"), None) == "IPY_MODEL_abc"
+
+
+def test_to_json_recurses_into_lists_and_dicts() -> None:
+    assert _to_json([FakeAnywidget("a"), 42], None) == ["IPY_MODEL_a", 42]
+    assert _to_json({"k": FakeAnywidget("b")}, None) == {"k": "IPY_MODEL_b"}
+
+
+def test_to_json_passthrough_for_plain_values() -> None:
+    assert _to_json(42, None) == 42
+    assert _to_json("hello", None) == "hello"
+
+
+def test_from_json_passthrough_when_unknown() -> None:
+    assert _from_json("IPY_MODEL_unknown", None) == "IPY_MODEL_unknown"
+    assert _from_json("not-a-ref", None) == "not-a-ref"
+
+
+def test_anywidget_trait_accepts_widgets() -> None:
+    trait = _AnyWidgetTrait()
+    assert trait.validate(None, FakeAnywidget()) is not None
+
+
+def test_anywidget_trait_rejects_plain_objects() -> None:
+    trait = _AnyWidgetTrait()
+    with pytest.raises(traitlets.TraitError):
+        trait.validate(traitlets.HasTraits(), object())
+
+
+def test_anywidget_trait_tuple_validates_ipywidgets_trait_name() -> None:
+    # For ipywidgets.Widget instances, we still verify the trait name exists
+    # and is sync'd — that's the validation users rely on for link()/dlink().
+    class W(ipywidgets.Widget):
+        v = traitlets.Int(0).tag(sync=True)
+
+    pair_trait = _AnyWidgetTraitTuple()
+    holder = traitlets.HasTraits()
+    w = W()
+    pair_trait.validate_elements(holder, (w, "v"))
+
+    with pytest.raises(TypeError, match="No such trait"):
+        pair_trait.validate_elements(holder, (w, "nope"))
+
+
+def test_anywidget_trait_tuple_skips_introspection_for_non_ipywidgets() -> None:
+    # Non-ipywidgets objects don't expose .traits(); we trust the user.
+    pair_trait = _AnyWidgetTraitTuple()
+    pair_trait.validate_elements(traitlets.HasTraits(), (FakeAnywidget(), "anything"))
+
+
+def test_hbox_accepts_anywidget_compatible() -> None:
+    foo = FakeAnywidget()
+    box = ipywidgets.HBox([foo])
+    assert box.children == (foo,)
+
+
+def test_hbox_serializes_children_with_ipy_prefix() -> None:
+    foo = FakeAnywidget("abc123")
+    box = ipywidgets.HBox([foo])
+    serialize = ipywidgets.Box.children.metadata["to_json"]
+    assert serialize(box.children, box) == ["IPY_MODEL_abc123"]
+
+
+def test_hbox_still_rejects_plain_objects() -> None:
+    with pytest.raises(traitlets.TraitError):
+        ipywidgets.HBox([object()])
+
+
+def test_link_accepts_anywidget_compatible() -> None:
+    a = FakeAnywidget("a")
+    b = FakeAnywidget("b")
+    link = ipywidgets.link((a, "value"), (b, "value"))
+    assert link.source[0] is a
+    assert link.target[0] is b
+
+
+def test_dlink_accepts_anywidget_compatible() -> None:
+    a = FakeAnywidget("a")
+    b = FakeAnywidget("b")
+    dlink = ipywidgets.dlink((a, "value"), (b, "value"))
+    assert dlink.source[0] is a
+    assert dlink.target[0] is b


### PR DESCRIPTION
Closes #629

Users routinely want `HBox([my_anywidget])` and `link((a, "x"), (b, "x"))` to just work; the new composition API in #974 solves anywidget-to-anywidget composition but leaves the bridge to ipywidgets' built-in containers unsolved.