### PR TITLE
fix: require svelte widget props in types

### DIFF
--- a/.changeset/serious-birds-wink.md
+++ b/.changeset/serious-birds-wink.md
@@ -1,0 +1,5 @@
+---
+"@anywidget/svelte": patch
+---
+
+Tighten Svelte widget component props so `model` and `bindings` are required.

--- a/packages/svelte/src/index.js
+++ b/packages/svelte/src/index.js
@@ -50,7 +50,7 @@ function createBindings(model) {
  * ```
  *
  * @template {Record<string, any>} T
- * @param {svelte.Component<{ model?: AnyModel<T>, bindings?: T }>} Widget
+ * @param {svelte.Component<{ model: AnyModel<T>, bindings: T }>} Widget
  * @returns {AnyWidget<T>}
  */
 export function defineWidget(Widget) {
@@ -63,9 +63,13 @@ export function defineWidget(Widget) {
       },
       /** @type {import("@anywidget/types").Render<T>} */
       render({ model, el }) {
+        if (bindings === undefined) {
+          throw new Error("Widget bindings were not initialized.");
+        }
+        let initializedBindings = bindings;
         let app = mount(Widget, {
           target: el,
-          props: { model, bindings },
+          props: { model, bindings: initializedBindings },
         });
         return () => unmount(app);
       },


### PR DESCRIPTION
## Summary
- Update the `@anywidget/svelte` `defineWidget` component type so `model` and `bindings` are required props.
- Add a runtime guard before mounting to keep the required `bindings` type sound.

Closes #1000

## Testing
- [x] `pnpm --filter @anywidget/svelte exec tsc --noEmit false --emitDeclarationOnly`
- [x] `pnpm exec tsc --build packages/svelte/tsconfig.json --pretty false`
- [x] `pnpm exec vp check packages/svelte/src/index.js`
