### PR TITLE
fix(svelte): remove optional markers from defineWidget component props

### DIFF
--- a/.changeset/fix-svelte-typing.md
+++ b/.changeset/fix-svelte-typing.md
@@ -1,0 +1,5 @@
+---
+"@anywidget/svelte": patch
+---
+
+Remove optional markers from `defineWidget` component props in JSDoc type annotation, so `model` and `bindings` are correctly typed as required (they are always provided in the render method).

--- a/packages/svelte/src/index.js
+++ b/packages/svelte/src/index.js
@@ -50,7 +50,7 @@ function createBindings(model) {
  * ```
  *
  * @template {Record<string, any>} T
- * @param {svelte.Component<{ model?: AnyModel<T>, bindings?: T }>} Widget
+ * @param {svelte.Component<{ model: AnyModel<T>, bindings: T }>} Widget
  * @returns {AnyWidget<T>}
  */
 export function defineWidget(Widget) {


### PR DESCRIPTION
## Summary

Removes the optional markers (`?`) from the `model` and `bindings` props in the JSDoc type annotation for `defineWidget`.

### Problem

The `defineWidget` function in `@anywidget/svelte` expects a Svelte component typed as:

```typescript
svelte.Component<{ model?: AnyModel<T>, bindings?: T }>
```

This makes `model` and `bindings` optional (can be `undefined`), but in reality they are always passed to the component in the `render` method. This causes TypeScript to require either explicit handling of `undefined` values or explicit type casts in user code.

### Solution

Change the type to:

```typescript
svelte.Component<{ model: AnyModel<T>, bindings: T }>
```

This correctly reflects that both props are always provided, eliminating the need for unnecessary `undefined` checks in user components.

Closes #1000